### PR TITLE
Substitute unnecessary matrix inversion, use linear solve instead.

### DIFF
--- a/test/MCMC/runtests.jl
+++ b/test/MCMC/runtests.jl
@@ -69,7 +69,6 @@ using CalibrateEmulateSample.GPEmulator
     # 1.0/sqrt(0.05) * obs_sample ≈ 4.472
     @test mcmc.obs_sample ≈ [4.472] atol=1e-2
     @test mcmc.obs_noise_cov == σ2_y
-    @test mcmc.obs_noise_covinv == inv(σ2_y)
     @test mcmc.burnin == burnin
     @test mcmc.algtype == mcmc_alg
     @test mcmc.iter[1] == max_iter + 1


### PR DESCRIPTION
This PR solves issue #73 . Inverting the observational covariance matrix is not necessary, a linear solve can be used instead. The linear solve is faster and more accurate, which can be important when the observational covariance matrix is large or ill-conditioned. 