### PR TITLE
GP bug for noise_learn = false underprediction of uncertainty

### DIFF
--- a/src/GaussianProcess.jl
+++ b/src/GaussianProcess.jl
@@ -192,6 +192,14 @@ function _predict(
     for i in 1:M
         μ[i, :], σ2[i, :] = predict_method(gp.models[i], new_inputs)
     end
+
+    if !(gp.noise_learn)
+        σ2[:,:] = σ2[:,:] .+ 1
+    else
+        magic_number = 1e-3
+        σ2[:,:] = σ2[:,:] .+ magic_number
+    end
+    
     return μ, σ2
 end
 

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -177,10 +177,10 @@ using CalibrateEmulateSample.DataContainers
 
     μ4, σ4² = Emulators.predict(em4, new_inputs, transform_to_real = true)
 
-    @test μ4[:, 1] ≈ [1.0, -1.0] atol = 0.3
-    @test μ4[:, 2] ≈ [0.0, 2.0] atol = 0.3
-    @test μ4[:, 3] ≈ [0.0, 0.0] atol = 0.3
-    @test μ4[:, 4] ≈ [0.0, -2.0] atol = 0.3
+    @test μ4[:, 1] ≈ [1.0, -1.0] atol = 0.2
+    @test μ4[:, 2] ≈ [0.0, 2.0] atol = 0.2
+    @test μ4[:, 3] ≈ [0.0, 0.0] atol = 0.2
+    @test μ4[:, 4] ≈ [0.0, -2.0] atol = 0.2
     @test length(σ4²) == size(new_inputs, 2)
     @test size(σ4²[1]) == (d, d)
 


### PR DESCRIPTION
# Purpose
Fix the `noise_learn = false` bug greatly underpredicting uncertainty. In Lorenz example, the following two should be similar. with `noise_learn=false` and `true`:
<img src="https://user-images.githubusercontent.com/47412152/170802229-877ba200-78c1-40bd-b5fd-a07e8629b4eb.png" width="300"><img src="https://user-images.githubusercontent.com/47412152/170802234-6bb83e79-5738-4b2e-b72e-004e10163b84.png" width="300">

co-author with @lm2612

# In this PR
- Initial bugfix to correct the regularization noise vs white kernel
- Tighten runtests thanks to improved prediction