### PR TITLE
julia ^1.6, EKP ^0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ MCMCChains = "4.14"
 PyCall = "1.93"
 ScikitLearn = "0.6"
 StatsBase = "0.33"
-julia = "~1.6"
+julia = "1.6"
 
 [extras]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"


### PR DESCRIPTION
## Purpose
- Remove `^0.8` for EKP in Project toml as this is default behaviour
- Change `~1.6` to `1.6` to widen Julia compat

