### PR TITLE
fix testing bugs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
     command:
       - "echo $$JULIA_DEPOT_PATH"
       - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project -e 'using Conda; Conda.add(\"scipy=1.8.1\")'"
+      - "julia --project -e 'using Conda; Conda.add(\"scipy=1.8.1\", channel=\"conda-forge\")'"
       - "julia --project -e 'using Conda; Conda.add(\"scikit-learn=1.1.1\")'"
       - "julia --project -e 'using Conda; Conda.add(\"matplotlib\")'"
     env:
@@ -24,9 +24,9 @@ steps:
   - label: "Lorenz"
     key: "lorenz"
     command: |
-      export PYTHON="$$JULIA_DEPOT_PATH/conda/3/bin/python"
-      export PYTHONHOME="$$JULIA_DEPOT_PATH/conda/3/bin"
-      export CONDA_JL_HOME="$$JULIA_DEPOT_PATH/conda/3"
+      export PYTHON="$$JULIA_DEPOT_PATH/conda/3/x86_64/bin/python"
+      export PYTHONHOME="$$JULIA_DEPOT_PATH/conda/3/x86_64/bin"
+      export CONDA_JL_HOME="$$JULIA_DEPOT_PATH/conda/3/x86_64"
 
       mkdir examples/Lorenz/depot
       export JULIA_DEPOT_PATH="$$(pwd)/examples/Lorenz/depot:$$JULIA_DEPOT_PATH"
@@ -51,9 +51,9 @@ steps:
   - label: "Gaussian Process Emulator"
     key: "gaussian_process_emulator"
     command: |
-      export PYTHON="$$JULIA_DEPOT_PATH/conda/3/bin/python"
-      export PYTHONHOME="$$JULIA_DEPOT_PATH/conda/3/bin"
-      export CONDA_JL_HOME="$$JULIA_DEPOT_PATH/conda/3"
+      export PYTHON="$$JULIA_DEPOT_PATH/conda/3/x86_64/bin/python"
+      export PYTHONHOME="$$JULIA_DEPOT_PATH/conda/3/x86_64/bin"
+      export CONDA_JL_HOME="$$JULIA_DEPOT_PATH/conda/3/x86_64/"
 
       mkdir examples/Emulator/GaussianProcess/depot
       export JULIA_DEPOT_PATH="$$(pwd)/examples/Emulator/GaussianProcess/depot:$JULIA_DEPOT_PATH"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,5 +7,5 @@ if lowercase(get(ENV, "CI", "false")) == "true"
     Pkg.build("PyCall")
 end
 
-Conda.add("scipy=1.8.1")
+Conda.add("scipy=1.8.1", channel = "conda-forge")
 Conda.add("scikit-learn=1.1.1")

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -5,6 +5,7 @@ using GaussianProcesses
 using Test
 
 using CalibrateEmulateSample.MarkovChainMonteCarlo
+const MCMC = MarkovChainMonteCarlo
 using CalibrateEmulateSample.ParameterDistributions
 using CalibrateEmulateSample.Emulators
 using CalibrateEmulateSample.DataContainers
@@ -92,8 +93,8 @@ function mcmc_test_template(
     # First let's run a short chain to determine a good step size
     new_step = optimize_stepsize(mcmc; init_stepsize = step, N = 5000)
 
-    # Now begin the actual MCMC
-    chain = sample(rng, mcmc, 100_000; stepsize = new_step, discard_initial = 1000)
+    # Now begin the actual MCMC, sample is multiply exported so we qualify
+    chain = MCMC.sample(rng, mcmc, 100_000; stepsize = new_step, discard_initial = 1000)
     posterior_distribution = get_posterior(mcmc, chain)
     #post_mean = mean(posterior, dims=1)[1]
     posterior_mean = mean(posterior_distribution)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
No direct issue. Bugs found during other testing, 
- scikit learn leads to conda issues (i.e. trying to install a non-existent package (`libstdcxx-ngnothing`) presumably due to some typo internally, or "broken SAT solver" message due to pycosat)
- `MarkovChainMonteCarlo`s `sample()` export leads to test breaking in some julia versions
- GP test fails due to random seed changes
- buildkite fails for scikit-learn

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- removes @sk_learn macro, which ignored the installed Conda/PyCall and created its own (buggy) installation of conda. Instead, always uses `PyCall`
- adds `MCMC.sample` qualifier in tests
- loosens GP tolerances for more robust testing under different random seeds
- bug due to changed conda / python paths in buildkite between instantiate project and running plot_GP example. Unifying these paths solves the issue

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
