### PR TITLE
Orad/amcmc piracy

### DIFF
--- a/examples/GCM/emulate_sample_script.jl
+++ b/examples/GCM/emulate_sample_script.jl
@@ -4,35 +4,42 @@
 using Distributions  # probability distributions and associated functions
 using LinearAlgebra
 using Plots
+using StatsPlots
 using Random
 using JLD2
 # CES 
 using CalibrateEmulateSample.Emulators
 using CalibrateEmulateSample.MarkovChainMonteCarlo
 using CalibrateEmulateSample.ParameterDistributions
+using CalibrateEmulateSample.EnsembleKalmanProcesses
 using CalibrateEmulateSample.DataContainers
 
-@time begin
 
+function main()
     rng_seed = 2413798
     Random.seed!(rng_seed)
 
-    #    expname = "vrf-nondiag-logdet_newprior"
-    #emulator_type ∈ ["GPR","ScalarRFR","VectorRFR-svd-diag","VectorRFR-svd-nondiag", "VectorRFR-nondiag"]
-    #    emulator_type = "GPR"
-    #    expname = "gpr"
+    # CHOOSE YOUR CASE 
+    case = 3
 
-    #    emulator_type = "ScalarRFR"
-    #    expname = "srf"
+    emulator_types = [
+        "GPR",
+        "ScalarRFR",
+        "VectorRFR-svd-diag",
+        "VectorRFR-svd-nondiag",
+        "VectorRFR-nondiag",
+    ]
+    
+    expnames = [
+        "gpr",
+        "srf",
+        "vrf-svd-diag",
+        "vrf-svd-nondiag",
+        "vrf-nondiag_standardized",
+    ]
 
-    #    emulator_type = "VectorRFR-svd-diag"
-    #    expname = "vrf-svd-diag"
-
-    #    emulator_type = "VectorRFR-svd-nondiag"
-    #    expname = "vrf-svd-nondiag"
-
-    emulator_type = "VectorRFR-nondiag"
-    expname = "vrf-nondiag_standardized"
+    emulator_type = emulator_types[case]
+    expname = expnames[case]
 
     # Output figure save directory
     example_directory = @__DIR__
@@ -54,11 +61,11 @@ using CalibrateEmulateSample.DataContainers
     obs_noise_cov = load(datafile)["obs_noise_cov"] # 96 x 96
 
     #take only first 400 points
-    iter_mask = 1:4
-    #data_mask = 1:32
+    iter_mask = [1,2,4]
+    data_mask = 1:96
     #    data_mask= 33:64
     #    data_mask= 65:96
-    data_mask = 1:96
+    #data_mask = 1:96
     #data_mask = [5*i for i = 1:Int(floor(96/5))]
 
     inputs = inputs[:, :, iter_mask]
@@ -66,8 +73,6 @@ using CalibrateEmulateSample.DataContainers
     obs_noise_cov = obs_noise_cov[data_mask, data_mask]
     truth = truth[data_mask]
 
-    # priorfile = "priors.jld2"
-    # prior = load(priorfile)["prior"]
 
     # derived quantities
     N_ens, input_dim, N_iter = size(inputs)
@@ -79,7 +84,15 @@ using CalibrateEmulateSample.DataContainers
     normalized = true
 
     # setup random features
-    eki_options_override = Dict("tikhonov" => 0, "multithread" => "ensemble") #faster than tullio multithread for training
+    eki_options_override = Dict(
+        "verbose" => true,
+        "tikhonov" => 0,
+        "scheduler" => DataMisfitController(),
+        "n_iteration" => 40,
+        "multithread" => "ensemble",
+        "train_fraction" => 0.8, 
+        "cov_sample_multiplier" => 2,
+    )
 
 
     if emulator_type == "VectorRFR-svd-nondiag" || emulator_type == "VectorRFR-nondiag"
@@ -89,18 +102,21 @@ using CalibrateEmulateSample.DataContainers
             println("Running Vector RF model - without SVD and assuming non-diagonal variance ")
         end
 
-        n_features = 80 * Int(floor(5 * sqrt(N_ens * N_iter)))
+        n_features = 20 * Int(floor(5 * sqrt(N_ens * N_iter))) #80 *
         println("build RF with $(N_ens*N_iter) training points and $(n_features) random features.")
-
+        eki_options_override["prior_in_scale"] = 1e-1
+        eki_options_override["prior_out_scale"] = 1e-1    
 
         mlt = VectorRandomFeatureInterface(n_features, input_dim, output_dim, optimizer_options = eki_options_override)
 
     elseif emulator_type == "VectorRFR-svd-diag"
 
         println("Running Vector RF model - using SVD and assuming diagonal variance")
-        n_features = 20 * Int(floor(5 * sqrt(N_ens * N_iter)))
+        n_features = 8 * Int(floor(5 * sqrt(N_ens * N_iter))) #20 *
         println("build RF with $(N_ens*N_iter) training points and $(n_features) random features.")
 
+        eki_options_override["prior_in_scale"] = 1e-2
+        eki_options_override["prior_out_scale"] = 1e-2    
         mlt = VectorRandomFeatureInterface(
             n_features,
             input_dim,
@@ -231,8 +247,76 @@ using CalibrateEmulateSample.DataContainers
             end
         end
 
-    end
+    end # plots
+
+### MCMC
+
+priorfile = "priors.jld2"
+prior = load(priorfile)["prior"]
+
+##
+###  Sample: Markov Chain Monte Carlo
+###
+# initial values
+u0 = vec(mean(get_inputs(input_output_pairs), dims = 2))
+println("initial parameters: ", u0)
+
+# First let's run a short chain to determine a good step size
+mcmc = MCMCWrapper(RWMHSampling(), truth, prior, emulator; init_params = u0)
+new_step = optimize_stepsize(mcmc; init_stepsize = 0.1, N = 2000, discard_initial = 0)
+
+# Now begin the actual MCMC
+println("Begin MCMC - with step size ", new_step)
+chain = MarkovChainMonteCarlo.sample(mcmc, 100_000; stepsize = new_step, discard_initial = 2_000)
+posterior = MarkovChainMonteCarlo.get_posterior(mcmc, chain)
+
+post_mean = mean(posterior)
+post_cov = cov(posterior)
+println("post_mean")
+println(post_mean)
+println("post_cov")
+println(post_cov)
+println("D util")
+println(det(inv(post_cov)))
+println(" ")
+
+
+# plot posterior
+
+truth_params = [ log(0.7 / 0.3) log(7200)]' # parameter value (at truth) - unconstrained
+
+# Save data
+save(
+    joinpath(data_save_directory, expname*"posterior.jld2"),
+    "posterior",
+    posterior,
+    "input_output_pairs",
+    input_output_pairs,
+    "truth_params",
+    truth_params,
+)
+
+
+constrained_truth_params = transform_unconstrained_to_constrained(posterior, truth_params)
+param_names = get_name(posterior)
+
+posterior_samples = vcat([get_distribution(posterior)[name] for name in param_names]...) #samples are columns
+constrained_posterior_samples =
+    mapslices(x -> transform_unconstrained_to_constrained(posterior, x), posterior_samples, dims = 1)
+
+gr(dpi = 300, size = (300, 300))
+p = cornerplot(permutedims(constrained_posterior_samples, (2, 1)), label = param_names, compact = true)
+plot!(p.subplots[1], [constrained_truth_params[1]], seriestype = "vline", w = 1.5, c = :steelblue, ls = :dash) # vline on top histogram
+plot!(p.subplots[3], [constrained_truth_params[2]], seriestype = "hline", w = 1.5, c = :steelblue, ls = :dash) # hline on right histogram
+plot!(p.subplots[2], [constrained_truth_params[1]], seriestype = "vline", w = 1.5, c = :steelblue, ls = :dash) # v & h line on scatter.
+plot!(p.subplots[2], [constrained_truth_params[2]], seriestype = "hline", w = 1.5, c = :steelblue, ls = :dash)
+figpath = joinpath(figure_save_directory, "plot_posterior_" * expname * ".png")
+savefig(figpath)
 
 
 
+end # main
+
+@time begin
+main()
 end # for @time

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -211,7 +211,7 @@ AdvancedMH.logdensity(model::AdvancedMH.DensityModel, t::MCMCState) = t.log_dens
 
 # AdvancedMH.transition() is only called to create a new proposal, so create a MCMCState
 # with accepted = true since that object will only be used if proposal is accepted.
-function AdvancedMH.transition(sampler::AdvancedMH.MHSampler, model::AdvancedMH.DensityModel, params, log_density::Real)
+function AdvancedMH.transition(sampler::MHS, model::AdvancedMH.DensityModel, params, log_density::Real) where {MHS <: Union{pCNMetropolisHastings,RWMetropolisHastings}}
     return MCMCState(params, log_density, true)
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Resolves #221 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- `AbstractMH.transition` is extended to new sampler types, rather than also pirating `AbstractMH` types

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
