### PR TITLE
Extend `AdvancedMH.transition` to CES types only

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
       - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project -e 'using Conda; Conda.add(\"scipy=1.8.1\", channel=\"conda-forge\")'"
       - "julia --project -e 'using Conda; Conda.add(\"scikit-learn=1.1.1\")'"
-      - "julia --project -e 'using Conda; Conda.add(\"matplotlib\")'"
+      - "julia --project -e 'using Conda; Conda.add(\"matplotlib=3.7.1\")'"
     env:
       PYTHON: ""
     agents:

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -211,7 +211,12 @@ AdvancedMH.logdensity(model::AdvancedMH.DensityModel, t::MCMCState) = t.log_dens
 
 # AdvancedMH.transition() is only called to create a new proposal, so create a MCMCState
 # with accepted = true since that object will only be used if proposal is accepted.
-function AdvancedMH.transition(sampler::AdvancedMH.MHSampler, model::AdvancedMH.DensityModel, params, log_density::Real)
+function AdvancedMH.transition(
+    sampler::MHS,
+    model::AdvancedMH.DensityModel,
+    params,
+    log_density::Real,
+) where {MHS <: Union{pCNMetropolisHastings, RWMetropolisHastings}}
     return MCMCState(params, log_density, true)
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Resolves #221 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- extends `AdvancedMH.transition` to CES types only.

### Also
- Pinning matplotlib version in buildkite to prevent buildkite error.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
