### PR TITLE
Update to new EKP (remove local posdef_correct) & typo fix

### DIFF
--- a/src/ScalarRandomFeature.jl
+++ b/src/ScalarRandomFeature.jl
@@ -394,7 +394,7 @@ function build_models!(
         accelerator = optimizer_options["accelerator"]
 
         initial_params = construct_initial_ensemble(rng, prior, n_ensemble)
-        min_complexity = log(regularization.λ)
+        min_complexity = n_features_opt * log(regularization.λ)
         min_complexity = sqrt(abs(min_complexity))
         data = vcat(get_outputs(io_pairs_opt)[(n_train + 1):end], 0.0, min_complexity)
         ekiobj = EKP.EnsembleKalmanProcess(

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -14,7 +14,6 @@ export get_training_points
 export get_obs_sample
 export orig2zscore
 export zscore2orig
-export posdef_correct
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
@@ -119,32 +118,5 @@ function zscore2orig(Z::AbstractMatrix{FT}, mean::AbstractVector{FT}, std::Abstr
     end
     return X
 end
-
-
-"""
-$(DocStringExtensions.TYPEDSIGNATURES)
-
-Makes square matrix `mat` positive definite, by symmetrizing and bounding the minimum eigenvalue below by `tol`
-"""
-function posdef_correct(mat::AbstractMatrix; tol::Real = 1e8 * eps())
-    if !issymmetric(mat)
-        out = 0.5 * (mat + permutedims(mat, (2, 1))) #symmetrize
-        if isposdef(out)
-            # very often, small numerical errors cause asymmetry, so cheaper to add this branch
-            return out
-        end
-    else
-        out = mat
-    end
-
-    nugget = abs(minimum(eigvals(out)))
-    for i in 1:size(out, 1)
-        out[i, i] += nugget + tol #add to diag
-    end
-    return out
-end
-
-
-
 
 end # module


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Scalar weight needed a multiplication to make consistent with theory & vector case.
- Removes `posdef_correct` which is causing test failures due to new EKP export of a function with the same name. (We default to using the EKP version)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
