### PR TITLE
Bugfix parameter name bug for MV distributions, cap mac-os tests to julia v1.9.0

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -80,8 +80,8 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.9.0
-        
+        version: 1.9.1
+                 # later versions causes hanging in package building
     - name: Install Julia Project Packages
       env:
         PYTHON: ""

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.9.2
+        version: 1.9.0
         
     - name: Install Julia Project Packages
       env:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.8.5
+        version: 1.9.2
         
     - name: Install Julia Project Packages
       env:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.9.3
-
+        version: 1
+        
     - name: Install Julia Project Packages
       # we add this ENV varaible to force PyCall to download and use Conda rather than
       # the system python (default on Linux), see the PyCall documentation
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1
+        version: 1.9.3
 
     - name: Install Julia Project Packages
       env:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1
+        version: 1.9.3
 
     - name: Install Julia Project Packages
       # we add this ENV varaible to force PyCall to download and use Conda rather than

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -80,8 +80,8 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.9.3
-
+        version: 1.8.5
+        
     - name: Install Julia Project Packages
       env:
         PYTHON: ""

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.9.1
+        version: 1.9.0
                  # later versions causes hanging in package building
     - name: Install Julia Project Packages
       env:

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -302,8 +302,8 @@ function AbstractMCMC.bundle_samples(
     # Check if we received any parameter names.
     if ismissing(param_names)
         param_names = [Symbol(:param_, i) for i in 1:length(keys(ts[1].params))]
-    elseif length(param_names) < length(keys(ts[1].params))# in case bug with MV names, Chains still needs one name per dist.
-        param_names = [Symbol(:param_, i) for i in 1:length(keys(ts[1].params))]
+        #    elseif length(param_names) < length(keys(ts[1].params))# in case bug with MV names, Chains still needs one name per dist.
+        #        param_names = [Symbol(:param_, i) for i in 1:length(keys(ts[1].params))]
     else
         # Generate new array to be thread safe.
         param_names = Symbol.(param_names)
@@ -352,8 +352,8 @@ function AbstractMCMC.bundle_samples(
     # Check if we received any parameter names.
     if ismissing(param_names)
         param_names = [Symbol(:param_, i) for i in 1:length(keys(ts[1][1].params))]
-    elseif length(param_names) < length(keys(ts[1][1].params)) # in case bug with MV names, Chains still needs one name per dist.
-        param_names = [Symbol(:param_, i) for i in 1:length(keys(ts[1][1].params))]
+        #    elseif length(param_names) < length(keys(ts[1][1].params)) # in case bug with MV names, Chains still needs one name per dist.
+        #        param_names = [Symbol(:param_, i) for i in 1:length(keys(ts[1][1].params))]
     else
         # Generate new array to be thread safe.
         param_names = Symbol.(param_names)

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -96,8 +96,8 @@ AdvancedMH.logratio_proposal_density(
 
 function _get_proposal(prior::ParameterDistribution)
     # *only* use covariance of prior, not full distribution
-    Σ = ParameterDistributions.cov(prior)
-    return AdvancedMH.RandomWalkProposal(Σ * MvNormal(zeros(size(Σ)[1]), I))
+    Σsqrt = sqrt(ParameterDistributions.cov(prior)) # rt_cov * MVN(0,I) avoids the posdef errors for MVN in Julia Distributions   
+    return AdvancedMH.RandomWalkProposal(Σsqrt * MvNormal(zeros(size(Σsqrt)[1]), I))
 end
 
 """

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -34,6 +34,33 @@ function test_prior()
     return ParameterDistribution(prior_dist, prior_constraint, prior_name)
 end
 
+function test_prior_mv()
+    ### Define prior
+    return constrained_gaussian("u_mv", -1.0, 6.0, -Inf, Inf, repeat = 10)
+end
+
+function test_data_mv(; rng_seed = 41, n = 20, var_y = 0.05, input_dim = 10, rest...)
+    # Seed for pseudo-random number generator
+    rng = Random.MersenneTwister(rng_seed)
+    n = 40                                              # number of training points
+    x = 1 / input_dim * π * rand(rng, Float64, (input_dim, n))                 # predictors/features: 1 × n
+    σ2_y = reshape([var_y], 1, 1)
+    y = sin.(norm(x)) + rand(rng, Normal(0, σ2_y[1]), (1, n)) # predictands/targets: 1 × n
+
+    return y, σ2_y, PairedDataContainer(x, y, data_are_columns = true), rng
+end
+function test_gp_mv(y, σ2_y, iopairs::PairedDataContainer; norm_factor = nothing)
+    gppackage = GPJL()
+    pred_type = YType()
+    # Construct kernel:
+    # Squared exponential kernel (note that hyperparameters are on log scale)
+    # with observational noise
+    gp = GaussianProcess(gppackage; noise_learn = true, prediction_type = pred_type)
+    em = Emulator(gp, iopairs; obs_noise_cov = σ2_y)
+    Emulators.optimize_hyperparameters!(em)
+    return em
+end
+
 function test_gp_1(y, σ2_y, iopairs::PairedDataContainer; norm_factor = nothing)
     gppackage = GPJL()
     pred_type = YType()
@@ -115,6 +142,17 @@ end
         # The MCMC stored a SVD-transformed sample,
         # 1.0/sqrt(0.05) * obs_sample ≈ 4.472
         @test isapprox(test_obs, (obs_sample ./ sqrt(σ2_y[1, 1])); atol = 1e-2)
+    end
+
+    @testset "MV priors" begin
+        # 10D dist with 1 name, just build the wrapper for test
+        prior_mv = test_prior_mv()
+        y_mv, σ2_y_mv, iopairs_mv, rng_mv = test_data(input_dim = 10)
+        init_params = repeat([0.0], 10)
+        obs_sample = obs_sample # scalar or Vector -> Vector
+        em_mv = test_gp_mv(y_mv, σ2_y_mv, iopairs_mv)
+        mcmc = MCMCWrapper(RWMHSampling(), obs_sample, prior_mv, em_mv; init_params = init_params)
+
     end
 
     @testset "Sine GP & RW Metropolis" begin

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -36,7 +36,7 @@ end
 
 function test_prior_mv()
     ### Define prior
-    return constrained_gaussian("u_mv", -1.0, 6.0, -Inf, Inf, repeat = 10)
+    return constrained_gaussian("u_mv", -1.0, 6.0, -Inf, Inf, repeats = 10)
 end
 
 function test_data_mv(; rng_seed = 41, n = 20, var_y = 0.05, input_dim = 10, rest...)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
MCMCChains requires one name per dimension for MCMC diagnostics. This causes an error when Multivariate distributions are used. This PR fixes this bug.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- uses the dimension of prior distribution in MCMC to clone the name e.g. a 3D "u" -> ["u_1","u_2","u_3"] 
- adds a quick unit-test for a case where #names < #prior dimensions

## Misc
- using `sqrt(C) * MVNormal(0,I)` instead of `MVNormal(0,C)`
- for an unknown reason, the Mac tests with v1.9.1 onwards are hanging on the package build of CES, so capping at v1.9.0

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
