### PR TITLE
added link to examples/ dir to docs

### DIFF
--- a/docs/src/examples/Cloudy_example.md
+++ b/docs/src/examples/Cloudy_example.md
@@ -1,5 +1,7 @@
 # [Learning the initial parameters of a droplet mass distribution in Cloudy](@id Cloudy-example)
 
+!!! info "How do I run this code?"
+    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
 
 This example is based on [Cloudy](https://github.com/CliMA/Cloudy.jl.git), a
 microphysics model that simulates how cloud droplets collide and coalesce into

--- a/docs/src/examples/edmf_example.md
+++ b/docs/src/examples/edmf_example.md
@@ -1,5 +1,8 @@
 # Extended Eddy-Diffusivity Mass-Flux (EDMF) Scheme
 
+!!! info "How do I run this code?"
+    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+
 ## Background
 The extended EDMF scheme is a unified model of turbulence and convection. More information about the model can be found [here](https://clima.github.io/TurbulenceConvection.jl/stable/). This example builds an emulator of the extended EDMF scheme from input-output pairs obtained during a calibration process, and runs emulator-based MCMC to obtain an estimate of the joint parameter distribution.
 
@@ -24,6 +27,7 @@ and call,
 ```
 > julia --project uq_for_EDMF.jl
 ```
+
 !!! info
     These runs take currently take ~1-3 hours to complete with Gaussian process emulator. Random feature training currently requires significant multithreading for performance and takes a similar amount of time.
 

--- a/docs/src/examples/emulators/ishigami_3d_1d.md
+++ b/docs/src/examples/emulators/ishigami_3d_1d.md
@@ -1,7 +1,7 @@
 # Global Sensitiviy Analysis for an emulated Ishigami function
 
 !!! info "How do I run this code?"
-    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+    The full code is found in the [`examples/Emulator/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples/Emulator) directory of the github repository
 
 In this example, we assess directly the performance of our machine learning emulators. The task is to learn a function for use in a [global sensitivity analysis](https://en.wikipedia.org/wiki/Variance-based_sensitivity_analysis). In particular, we learn the Ishigami function
 ```math

--- a/docs/src/examples/emulators/ishigami_3d_1d.md
+++ b/docs/src/examples/emulators/ishigami_3d_1d.md
@@ -1,5 +1,8 @@
 # Global Sensitiviy Analysis for an emulated Ishigami function
 
+!!! info "How do I run this code?"
+    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+
 In this example, we assess directly the performance of our machine learning emulators. The task is to learn a function for use in a [global sensitivity analysis](https://en.wikipedia.org/wiki/Variance-based_sensitivity_analysis). In particular, we learn the Ishigami function
 ```math
 f(x; a, b) = (1 + bx_3^4)\sin(x_1) + a \sin(x_2), \forall x\in [-\pi,\pi]^3

--- a/docs/src/examples/emulators/lorenz_integrator_3d_3d.md
+++ b/docs/src/examples/emulators/lorenz_integrator_3d_3d.md
@@ -1,7 +1,7 @@
 # Integrating Lorenz 63 with an emulated integrator
 
 !!! info "How do I run this code?"
-    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+    The full code is found in the [`examples/Emulator/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples/Emulator) directory of the github repository
 
 In this example, we assess directly the performance of our machine learning emulators. The task is to learn the forward Euler integrator of a [Lorenz 63 system](https://en.wikipedia.org/wiki/Lorenz_system). The model parameters are set to their classical settings ``(\sigma, \rho, \beta) = (10,28,\frac{8}{3})`` to exhibit chaotic behavior. The discrete system is given as:
 

--- a/docs/src/examples/emulators/lorenz_integrator_3d_3d.md
+++ b/docs/src/examples/emulators/lorenz_integrator_3d_3d.md
@@ -1,5 +1,8 @@
 # Integrating Lorenz 63 with an emulated integrator
 
+!!! info "How do I run this code?"
+    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+
 In this example, we assess directly the performance of our machine learning emulators. The task is to learn the forward Euler integrator of a [Lorenz 63 system](https://en.wikipedia.org/wiki/Lorenz_system). The model parameters are set to their classical settings ``(\sigma, \rho, \beta) = (10,28,\frac{8}{3})`` to exhibit chaotic behavior. The discrete system is given as:
 
 ```math

--- a/docs/src/examples/emulators/regression_2d_2d.md
+++ b/docs/src/examples/emulators/regression_2d_2d.md
@@ -1,7 +1,7 @@
 # Regression of ``\mathbb{R}^2 \to \mathbb{R}^2`` smooth function
 
 !!! info "How do I run this code?"
-    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+    The full code is found in the [`examples/Emulator/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples/Emulator) directory of the github repository
 
 In this example, we assess directly the performance of our machine learning emulators. The task is to learn the function:
 

--- a/docs/src/examples/emulators/regression_2d_2d.md
+++ b/docs/src/examples/emulators/regression_2d_2d.md
@@ -1,5 +1,8 @@
 # Regression of ``\mathbb{R}^2 \to \mathbb{R}^2`` smooth function
 
+!!! info "How do I run this code?"
+    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+
 In this example, we assess directly the performance of our machine learning emulators. The task is to learn the function:
 
 ```math

--- a/docs/src/examples/lorenz_example.md
+++ b/docs/src/examples/lorenz_example.md
@@ -1,5 +1,8 @@
 # Lorenz 96 example
 
+!!! info "How do I run this code?"
+    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+
 The Lorenz 96 (hereafter L96) example is a toy-problem for the application of the `CalibrateEmulateSample.jl` optimization and approximate uncertainty quantification methodologies.
 Here is L96 with additional periodic-in-time forcing, we try to determine parameters (sinusoidal amplitude and stationary component of the forcing) from some output statistics.
 The standard L96 equations are implemented with an additional forcing term with time dependence.

--- a/docs/src/examples/sinusoid_example.md
+++ b/docs/src/examples/sinusoid_example.md
@@ -1,5 +1,8 @@
 # Sinusoid Example
 
+!!! info "How do I run this code?"
+    The full code is found in the [`examples/`](https://github.com/CliMA/CalibrateEmulateSample.jl/tree/main/examples) directory of the github repository
+
 ## Background
 This example demonstrates how to use CalibrateEmulateSample.jl for a simple model that generates noisy
 observables of a signal. The sinusoid signal is defined by two parameters: its shift along the vertical axis


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Addresses an linking issue of #283 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Adds an info statement at the top of each example pointing to the director `examples/` 

See the result [here:](https://clima.github.io/CalibrateEmulateSample.jl/previews/PR290/examples/sinusoid_example/)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
