### PR TITLE
JOSS: Emulator docstring and warning

### DIFF
--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -6,7 +6,7 @@ CurrentModule = CalibrateEmulateSample.Emulators
 
 ```@docs
 Emulator
-function Emulator(
+Emulator(
     ::MachineLearningTool,
     ::PairedDataContainer{FT};
     ::Union{AbstractMatrix{FT}, UniformScaling{FT}, Nothing},

--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -9,12 +9,6 @@ Emulator
 Emulator(
     ::MachineLearningTool,
     ::PairedDataContainer{FT};
-    ::Union{AbstractMatrix{FT}, UniformScaling{FT}, Nothing},
-    ::Bool,
-    ::Bool,
-    ::Union{AbstractVector{FT}, Nothing},
-    ::Bool,
-    ::FT,
 ) where {FT <: AbstractFloat}
 optimize_hyperparameters!(::Emulator)
 predict

--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -6,7 +6,16 @@ CurrentModule = CalibrateEmulateSample.Emulators
 
 ```@docs
 Emulator
-Emulator(::MachineLearningTool, ::PairedDataContainer{FT})  where {FT <: AbstractFloat}
+function Emulator(
+    ::MachineLearningTool,
+    ::PairedDataContainer{FT};
+    ::Union{AbstractMatrix{FT}, UniformScaling{FT}, Nothing},
+    ::Bool,
+    ::Bool,
+    ::Union{AbstractVector{FT}, Nothing},
+    ::Bool,
+    ::FT,
+) where {FT <: AbstractFloat}
 optimize_hyperparameters!(::Emulator)
 predict
 normalize

--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -6,7 +6,7 @@ CurrentModule = CalibrateEmulateSample.Emulators
 
 ```@docs
 Emulator
-Emulator(::MachineLearningTool, ::PairedDataContainer{FT})
+Emulator(::MachineLearningTool, ::PairedDataContainer{FT})  where {FT <: AbstractFloat}
 optimize_hyperparameters!(::Emulator)
 predict
 normalize

--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -6,10 +6,6 @@ CurrentModule = CalibrateEmulateSample.Emulators
 
 ```@docs
 Emulator
-Emulator(
-    ::MachineLearningTool,
-    ::PairedDataContainer{FT};
-) where {FT <: AbstractFloat}
 optimize_hyperparameters!(::Emulator)
 predict
 normalize

--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -6,6 +6,7 @@ CurrentModule = CalibrateEmulateSample.Emulators
 
 ```@docs
 Emulator
+Emulator(::MachineLearningTool, ::PairedDataContainer{FT}) where {FT <: AbstractFloat}
 optimize_hyperparameters!(::Emulator)
 predict
 normalize

--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -6,7 +6,6 @@ CurrentModule = CalibrateEmulateSample.Emulators
 
 ```@docs
 Emulator
-Emulator(::MachineLearningTool, ::PairedDataContainer{FT}) where {FT <: AbstractFloat}
 optimize_hyperparameters!(::Emulator)
 predict
 normalize

--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -6,6 +6,7 @@ CurrentModule = CalibrateEmulateSample.Emulators
 
 ```@docs
 Emulator
+Emulator()
 optimize_hyperparameters!(::Emulator)
 predict
 normalize

--- a/docs/src/API/Emulators.md
+++ b/docs/src/API/Emulators.md
@@ -6,7 +6,7 @@ CurrentModule = CalibrateEmulateSample.Emulators
 
 ```@docs
 Emulator
-Emulator()
+Emulator(::MachineLearningTool, ::PairedDataContainer{FT})
 optimize_hyperparameters!(::Emulator)
 predict
 normalize

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -91,9 +91,9 @@ Keyword Arguments
  - `obs_noise_cov`: A matrix/uniform scaling to provide the observational noise covariance of the data - used for data processing (default `nothing`),
  - `normalize_inputs`: Normalize the inputs to be unit Gaussian, in the smallest full-rank space of the data (default `true`),
  - `standardize_outputs`: Standardize outputs with by dividing by a vector of provided factors (default `false`),
- - `standardize_outputs_factors: If standardizing, the provided dim_output-length vector of factors,
+ - `standardize_outputs_factors`: If standardizing, the provided dim_output-length vector of factors,
  - `decorrelate`: Apply (truncated) SVD to the outputs. Predictions are returned in the decorrelated space, (default `true`)
- - `retained_svd_frac = 1.0`: The cumulative sum of singular values retained after output SVD truncation (default 1.0 - no truncation)
+ - `retained_svd_frac`: The cumulative sum of singular values retained after output SVD truncation (default 1.0 - no truncation)
 """
 function Emulator(
     machine_learning_tool::MachineLearningTool,

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -81,6 +81,20 @@ end
 get_machine_learning_tool(emulator::Emulator) = emulator.machine_learning_tool
 
 # Constructor for the Emulator Object
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Positional Arguments
+ - `machine_learning_tool` ::MachineLearningTool,
+ - `input_output_pairs` ::PairedDataContainer
+Keyword Arguments 
+ - `obs_noise_cov`: A matrix/uniform scaling to provide the observational noise covariance of the data - used for data processing (default `nothing`),
+ - `normalize_inputs`: Normalize the inputs to be unit Gaussian, in the smallest full-rank space of the data (default `true`),
+ - `standardize_outputs`: Standardize outputs with by dividing by a vector of provided factors (default `false`),
+ - `standardize_outputs_factors: If standardizing, the provided dim_output-length vector of factors,
+ - `decorrelate`: Apply (truncated) SVD to the outputs. Predictions are returned in the decorrelated space, (default `true`)
+ - `retained_svd_frac = 1.0`: The cumulative sum of singular values retained after output SVD truncation (default 1.0 - no truncation)
+"""
 function Emulator(
     machine_learning_tool::MachineLearningTool,
     input_output_pairs::PairedDataContainer{FT};
@@ -102,6 +116,8 @@ function Emulator(
     if obs_noise_cov !== nothing
         err2 = "obs_noise_cov must be of size ($output_dim, $output_dim), got $(size(obs_noise_cov))"
         size(obs_noise_cov) == (output_dim, output_dim) || throw(ArgumentError(err2))
+    else
+        @warn "The covariance of the observational noise (a.k.a obs_noise_cov) is useful for data processing. Large approximation errors can occur without it. If possible, please provide it using the keyword obs_noise_cov."
     end
 
 

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -72,7 +72,7 @@ using CalibrateEmulateSample.DataContainers
         retained_svd_frac = 1.0,
     )
 
-    @test_logs (:warn,) Emulator(
+    @test_logs (:warn,) (:warn,) Emulator(
         gp1,
         iopairs,
         obs_noise_cov = nothing,

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -139,7 +139,7 @@ using CalibrateEmulateSample.DataContainers
         retained_svd_frac = 1.0,
     )
 
-    @test_logs (:warn,) Emulator(
+    @test_logs (:warn,) (:warn,) Emulator(
         gp3,
         iopairs,
         obs_noise_cov = nothing,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Addressing #294 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Added a comprehensive dosctring for `Emulator(...)`
- Added a warning when not providing obs_noise_cov as a keyword

Due to the way manifests/GH actions work, will need a later PR to add the docs for this change

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
