### PR TITLE
Update climacommon to 2024_04_05

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   queue: new-central
-  modules: climacommon/2024_03_18 
+  modules: climacommon/2024_04_05 
   
 env:
   OPENBLAS_NUM_THREADS: 1


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖 Good news! I found a way to reduce unnecessary precompilations! Have you ever noticed that when you move to a GPU node from a CPU one (or viceversa), everything has to be recompiled again? Or sometimes it seems that you are always precompiling... Well, this is partially because the nodes on the Caltech cluster have different architectures, and Julia compiles for the native one, but when you move to a new architecture, the compiled code has to be invalidated and recompiled again. With the latest version of climacommon, I force Julia to always compile for all the possible targets in our cluster. Buildkite pipelines partially do this with the JULIA_TARGET_CPU, but the strings there are incorrect. This PR fixes that too. 