### PR TITLE
Function Parameters within CES & Darcy example

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.3"
+julia_version = "1.10.5"
 manifest_format = "2.0"
 project_hash = "e4d965798d55f5903483b71f545533e62ea32fdf"
 
@@ -92,16 +92,20 @@ uuid = "68821587-b530-5797-8361-c406ea357684"
 version = "3.5.1+1"
 
 [[deps.ArrayInterface]]
-deps = ["Adapt", "LinearAlgebra", "Requires", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "c5aeb516a84459e0318a02507d2261edad97eb75"
+deps = ["Adapt", "LinearAlgebra"]
+git-tree-sha1 = "3640d077b6dafd64ceb8fd5c1ec76f7ca53bcf76"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.7.1"
+version = "7.16.0"
 
     [deps.ArrayInterface.extensions]
     ArrayInterfaceBandedMatricesExt = "BandedMatrices"
     ArrayInterfaceBlockBandedMatricesExt = "BlockBandedMatrices"
     ArrayInterfaceCUDAExt = "CUDA"
+    ArrayInterfaceCUDSSExt = "CUDSS"
+    ArrayInterfaceChainRulesExt = "ChainRules"
     ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
+    ArrayInterfaceReverseDiffExt = "ReverseDiff"
+    ArrayInterfaceSparseArraysExt = "SparseArrays"
     ArrayInterfaceStaticArraysCoreExt = "StaticArraysCore"
     ArrayInterfaceTrackerExt = "Tracker"
 
@@ -109,7 +113,11 @@ version = "7.7.1"
     BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
     BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
     CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+    ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
     GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
     StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
     Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
@@ -184,7 +192,7 @@ version = "0.2.6"
 deps = ["AbstractMCMC", "AdvancedMH", "Conda", "Distributions", "DocStringExtensions", "EnsembleKalmanProcesses", "GaussianProcesses", "LinearAlgebra", "MCMCChains", "Pkg", "Printf", "ProgressBars", "PyCall", "Random", "RandomFeatures", "ScikitLearn", "StableRNGs", "Statistics", "StatsBase"]
 path = ".."
 uuid = "95e48a1f-0bec-4818-9538-3db4340308e3"
-version = "0.5.2"
+version = "0.5.3"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
@@ -203,28 +211,33 @@ uuid = "fb6a15b2-703c-40df-9091-08a04967cfa9"
 version = "0.1.13"
 
 [[deps.CodecBzip2]]
-deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
-git-tree-sha1 = "f8889d1770addf59d0a015c49a473fa2bdb9f809"
+deps = ["Bzip2_jll", "TranscodingStreams"]
+git-tree-sha1 = "e7c529cc31bb85b97631b922fa2e6baf246f5905"
 uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
-version = "0.8.3"
+version = "0.8.4"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "b8fe8546d52ca154ac556809e10c75e6e7430ac8"
+git-tree-sha1 = "bce6804e5e6044c6daab27bb533d1295e4a2e759"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.5"
+version = "0.7.6"
 
 [[deps.CommonSubexpressions]]
-deps = ["MacroTools", "Test"]
-git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+deps = ["MacroTools"]
+git-tree-sha1 = "cda2cfaebb4be89c9084adaca7dd7333369715c5"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
-version = "0.3.0"
+version = "0.3.1"
+
+[[deps.CommonWorldInvalidations]]
+git-tree-sha1 = "ae52d1c52048455e85a387fbee9be553ec2b68d0"
+uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
+version = "1.0.0"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "b1c55339b7c6c350ee89f2c1604299660525b248"
+git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.15.0"
+version = "4.16.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -233,7 +246,7 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.5+0"
+version = "1.1.1+0"
 
 [[deps.CompositionsBase]]
 git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
@@ -257,14 +270,14 @@ uuid = "88cd18e8-d9cc-4ea6-8889-5259c0d15c8b"
 version = "0.1.2"
 
 [[deps.ConstructionBase]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "d8a9c0b6ac2d9081bf76324b39c78ca3ce4f0c98"
+git-tree-sha1 = "76219f1ed5771adbb096743bff43fb5fdd4c1157"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
-version = "1.5.6"
-weakdeps = ["IntervalSets", "StaticArrays"]
+version = "1.5.8"
+weakdeps = ["IntervalSets", "LinearAlgebra", "StaticArrays"]
 
     [deps.ConstructionBase.extensions]
     ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
     ConstructionBaseStaticArraysExt = "StaticArrays"
 
 [[deps.Convex]]
@@ -344,9 +357,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "9c405847cc7ecda2dc921ccf18b47ca150d7317e"
+git-tree-sha1 = "e6c693a0e4394f8fda0e51a5bdf5aef26f8235e9"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.109"
+version = "0.25.111"
 
     [deps.Distributions.extensions]
     DistributionsChainRulesCoreExt = "ChainRulesCore"
@@ -366,9 +379,9 @@ version = "0.9.3"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "76deb8c15f37a3853f13ea2226b8f2577652de05"
+git-tree-sha1 = "5a1ee886566f2fa9318df1273d8b778b9d42712d"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.5.0"
+version = "1.7.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -383,9 +396,9 @@ version = "1.2.12"
 
 [[deps.ElasticPDMats]]
 deps = ["LinearAlgebra", "MacroTools", "PDMats"]
-git-tree-sha1 = "5157c93fe9431a041e4cd84265dfce3d53a52323"
+git-tree-sha1 = "03ec11d0151e8a772b396aecd663e1c76fc8edcf"
 uuid = "2904ab23-551e-5aed-883f-487f97af5226"
-version = "0.2.2"
+version = "0.2.3"
 
 [[deps.EnsembleKalmanProcesses]]
 deps = ["Convex", "Distributions", "DocStringExtensions", "GaussianRandomFields", "Interpolations", "LinearAlgebra", "MathOptInterface", "Optim", "QuadGK", "Random", "RecipesBase", "SCS", "SparseArrays", "Statistics", "StatsBase", "TOML"]
@@ -421,21 +434,22 @@ version = "0.4.9"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FillArrays]]
-deps = ["LinearAlgebra", "Random"]
-git-tree-sha1 = "35f0c0f345bff2c6d636f95fdb136323b5a796ef"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "6a70198746448456524cb442b8af316927ff3e1a"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.7.0"
-weakdeps = ["SparseArrays", "Statistics"]
+version = "1.13.0"
+weakdeps = ["PDMats", "SparseArrays", "Statistics"]
 
     [deps.FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
     FillArraysSparseArraysExt = "SparseArrays"
     FillArraysStatisticsExt = "Statistics"
 
 [[deps.FiniteDiff]]
-deps = ["ArrayInterface", "LinearAlgebra", "Requires", "Setfield", "SparseArrays"]
-git-tree-sha1 = "73d1214fec245096717847c62d389a5d2ac86504"
+deps = ["ArrayInterface", "LinearAlgebra", "Setfield", "SparseArrays"]
+git-tree-sha1 = "f9219347ebf700e77ca1d48ef84e4a82a6701882"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.22.0"
+version = "2.24.0"
 
     [deps.FiniteDiff.extensions]
     FiniteDiffBandedMatricesExt = "BandedMatrices"
@@ -527,10 +541,10 @@ version = "1.4.2"
     Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
 [[deps.IntelOpenMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "14eb2b542e748570b56446f4c50fbfb2306ebc45"
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "10bd689145d2c3b2a9844005d01087cc1194e79e"
 uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
-version = "2024.2.0+0"
+version = "2024.2.1+0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -560,14 +574,14 @@ weakdeps = ["Random", "RecipesBase", "Statistics"]
     IntervalSetsStatisticsExt = "Statistics"
 
 [[deps.InverseFunctions]]
-deps = ["Test"]
-git-tree-sha1 = "18c59411ece4838b18cd7f537e56cf5e41ce5bfd"
+git-tree-sha1 = "2787db24f4e03daf859c6509ff87764e4182f7d1"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.15"
-weakdeps = ["Dates"]
+version = "0.1.16"
+weakdeps = ["Dates", "Test"]
 
     [deps.InverseFunctions.extensions]
-    DatesExt = "Dates"
+    InverseFunctionsDatesExt = "Dates"
+    InverseFunctionsTestExt = "Test"
 
 [[deps.InvertedIndices]]
 git-tree-sha1 = "0dc7b50b8d436461be01300fd8cd45aa0274b038"
@@ -591,9 +605,9 @@ version = "1.0.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+git-tree-sha1 = "f389674c99bfcde17dc57454011aa44d5a260a40"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -615,9 +629,9 @@ version = "0.10.1"
 
 [[deps.LLVMOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "d986ce2d884d49126836ea94ed5bfb0f12679713"
+git-tree-sha1 = "e16271d212accd09d52ee0ae98956b8a05c4b626"
 uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
-version = "15.0.7+0"
+version = "17.0.6+0"
 
 [[deps.LaTeXStrings]]
 git-tree-sha1 = "50901ebc375ed41dbf8058da26f9de442febbbec"
@@ -648,21 +662,26 @@ version = "0.2.0"
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.3"
+version = "0.6.4"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "7.84.0+0"
+version = "8.4.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.10.2+0"
+version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -675,9 +694,9 @@ version = "1.17.0+0"
 
 [[deps.LineSearches]]
 deps = ["LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "Printf"]
-git-tree-sha1 = "7bbea35cec17305fc70a0e5b4641477dc0789d9d"
+git-tree-sha1 = "e4c3be53733db1051cc15ecf573b1042b3a712a1"
 uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
-version = "7.2.0"
+version = "7.3.0"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
@@ -772,14 +791,14 @@ version = "0.1.2"
 
 [[deps.MathOptInterface]]
 deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test", "Unicode"]
-git-tree-sha1 = "91b08d27a27d83cf1e63e50837403e7f53a0fd74"
+git-tree-sha1 = "5b246fca5420ae176d65ed43a2d0ee5897775216"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.31.0"
+version = "1.31.2"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+0"
+version = "2.28.2+1"
 
 [[deps.MicroCollections]]
 deps = ["BangBang", "InitialValues", "Setfield"]
@@ -798,13 +817,13 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.10.11"
+version = "2023.1.10"
 
 [[deps.MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "898c56fbf8bf71afb0c02146ef26f3a454e88873"
+git-tree-sha1 = "d0a6b1096b584a2b88efb70a92f8cb8c881eb38a"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-version = "1.4.5"
+version = "1.4.6"
 
 [[deps.NLSolversBase]]
 deps = ["DiffResults", "Distributed", "FiniteDiff", "ForwardDiff"]
@@ -837,26 +856,26 @@ weakdeps = ["Adapt"]
     OffsetArraysAdaptExt = "Adapt"
 
 [[deps.OpenBLAS32_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "2fb9ee2dc14d555a6df2a714b86b7125178344c2"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6065c4cff8fee6c6770b277af45d5082baacdba1"
 uuid = "656ef2d0-ae68-5445-9ca0-591084a874a2"
-version = "0.3.21+0"
+version = "0.3.24+0"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.21+4"
+version = "0.3.23+4"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.1+0"
+version = "0.8.1+2"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "a028ee3cb5641cccc4c24e90c36b0a4f7707bdf5"
+git-tree-sha1 = "1b35263570443fdd9e76c76b7062116e2f374ab8"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.14+0"
+version = "3.0.15+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -882,13 +901,13 @@ version = "1.6.3"
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.42.0+0"
+version = "10.42.0+1"
 
 [[deps.PDMats]]
-deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse", "Test"]
-git-tree-sha1 = "95a4038d1011dfdbde7cecd2ad0ac411e53ab1bc"
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "949347156c25054de2db3b166c52ac4728cbad65"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.10.1"
+version = "0.11.31"
 
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]
@@ -905,7 +924,7 @@ version = "2.8.1"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.9.2"
+version = "1.10.0"
 
 [[deps.PolyesterWeave]]
 deps = ["BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "Static", "ThreadingUtilities"]
@@ -970,9 +989,9 @@ uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.10.2"
 
 [[deps.PtrArrays]]
-git-tree-sha1 = "f011fbb92c4d401059b2212c05c0601b70f8b759"
+git-tree-sha1 = "77a42d78b6a92df47ab37e177b2deac405e1c88f"
 uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
-version = "1.2.0"
+version = "1.2.1"
 
 [[deps.PyCall]]
 deps = ["Conda", "Dates", "Libdl", "LinearAlgebra", "MacroTools", "Serialization", "VersionParsing"]
@@ -982,16 +1001,22 @@ version = "1.96.4"
 
 [[deps.QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
-git-tree-sha1 = "e237232771fdafbae3db5c31275303e056afaa9f"
+git-tree-sha1 = "1d587203cf851a51bf1ea31ad7ff89eff8d625ea"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.10.1"
+version = "2.11.0"
+
+    [deps.QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [deps.QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.RandomFeatures]]
@@ -1048,9 +1073,9 @@ version = "0.7.1"
 
 [[deps.Rmath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "d483cd324ce5cf5d61b77930f0bbd6cb61927d21"
+git-tree-sha1 = "e60724fd3beea548353984dc61c943ecddb0e29a"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.4.2+0"
+version = "0.4.3+0"
 
 [[deps.SCS]]
 deps = ["MathOptInterface", "Requires", "SCS_jll", "SparseArrays"]
@@ -1135,6 +1160,7 @@ version = "1.2.1"
 [[deps.SparseArrays]]
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.10.0"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
@@ -1159,16 +1185,16 @@ uuid = "860ef19b-820b-49d6-a774-d7a799459cd3"
 version = "1.0.2"
 
 [[deps.Static]]
-deps = ["IfElse"]
-git-tree-sha1 = "b366eb1eb68075745777d80861c6706c33f588ae"
+deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools"]
+git-tree-sha1 = "87d51a3ee9a4b0d2fe054bdd3fc2436258db2603"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "0.8.9"
+version = "1.1.1"
 
 [[deps.StaticArrayInterface]]
-deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "Requires", "SparseArrays", "Static", "SuiteSparse"]
-git-tree-sha1 = "8963e5a083c837531298fc41599182a759a87a6d"
+deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "Static"]
+git-tree-sha1 = "96381d50f1ce85f2663584c8e886a6ca97e60554"
 uuid = "0d7ed370-da01-4f52-bd93-41d350b8b718"
-version = "1.5.1"
+version = "1.8.0"
 weakdeps = ["OffsetArrays", "StaticArrays"]
 
     [deps.StaticArrayInterface.extensions]
@@ -1200,7 +1226,7 @@ version = "3.4.0"
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.9.0"
+version = "1.10.0"
 
 [[deps.StatsAPI]]
 deps = ["LinearAlgebra"]
@@ -1231,9 +1257,9 @@ deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[deps.SuiteSparse_jll]]
-deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
 uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "5.10.1+6"
+version = "7.2.1+1"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -1274,13 +1300,9 @@ uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 version = "0.5.2"
 
 [[deps.TranscodingStreams]]
-git-tree-sha1 = "96612ac5365777520c3c5396314c8cf7408f436a"
+git-tree-sha1 = "e84b3a11b9bece70d14cce63406bbc79ed3464d2"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.11.1"
-weakdeps = ["Random", "Test"]
-
-    [deps.TranscodingStreams.extensions]
-    TestExt = ["Test", "Random"]
+version = "0.11.2"
 
 [[deps.Transducers]]
 deps = ["Adapt", "ArgCheck", "BangBang", "Baselet", "CompositionsBase", "ConstructionBase", "DefineSingletons", "Distributed", "InitialValues", "Logging", "Markdown", "MicroCollections", "Requires", "Setfield", "SplittablesBase", "Tables"]
@@ -1352,17 +1374,17 @@ version = "1.0.0"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+0"
+version = "1.2.13+1"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+0"
+version = "5.11.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.48.0+0"
+version = "1.52.0+1"
 
 [[deps.oneTBB_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1373,4 +1395,4 @@ version = "2021.12.0+0"
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+0"
+version = "17.4.0+2"

--- a/examples/Darcy/GModel.jl
+++ b/examples/Darcy/GModel.jl
@@ -1,0 +1,219 @@
+##################
+# Copied on 3/16/23 and modified from 
+# https://github.com/Zhengyu-Huang/InverseProblems.jl/blob/master/Fluid/Darcy-2D.jl
+##################
+
+using JLD2
+using Statistics
+using LinearAlgebra
+using Distributions
+using Random
+using SparseArrays
+
+
+
+
+mutable struct Setup_Param{FT <: AbstractFloat, IT <: Int}
+    # physics
+    N::IT         # number of grid points for both x and y directions (including both ends)
+    Δx::FT
+    xx::AbstractVector{FT}  # uniform grid [a, a+Δx, a+2Δx ... b] (in each dimension)
+
+    #for source term
+    f_2d::AbstractMatrix{FT}
+
+    κ::AbstractMatrix{FT}
+
+    # observation locations is tensor product x_locs × y_locs
+    x_locs::AbstractVector{IT}
+    y_locs::AbstractVector{IT}
+
+    N_y::IT
+end
+
+
+function Setup_Param(
+    xx::AbstractVector{FT},
+    obs_ΔN::IT,
+    κ::AbstractMatrix;
+    seed::IT = 123,
+) where {FT <: AbstractFloat, IT <: Int}
+
+    N = length(xx)
+    Δx = xx[2] - xx[1]
+
+    #  logκ_2d, φ, λ, θ_ref = generate_θ_KL(xx, N_KL, d, τ, seed=seed)
+    f_2d = compute_f_2d(xx)
+
+    x_locs = Array(obs_ΔN:obs_ΔN:(N - obs_ΔN))
+    y_locs = Array(obs_ΔN:obs_ΔN:(N - obs_ΔN))
+    N_y = length(x_locs) * length(y_locs)
+
+    Setup_Param(N, Δx, xx, f_2d, κ, x_locs, y_locs, N_y)
+end
+
+
+
+#=
+A hardcoding source function, 
+which assumes the computational domain is
+[0 1]×[0 1]
+f(x,y) = f(y),
+which dependes only on y
+=#
+function compute_f_2d(yy::AbstractVector{FT}) where {FT <: AbstractFloat}
+    N = length(yy)
+    f_2d = zeros(FT, N, N)
+    for i in 1:N
+        if (yy[i] <= 4 / 6)
+            f_2d[:, i] .= 1000.0
+        elseif (yy[i] >= 4 / 6 && yy[i] <= 5 / 6)
+            f_2d[:, i] .= 2000.0
+        elseif (yy[i] >= 5 / 6)
+            f_2d[:, i] .= 3000.0
+        end
+    end
+    return f_2d
+end
+
+"""
+    run_G_ensemble(darcy,κs::AbstractMatrix)
+
+Computes the forward map `G` (`solve_Darcy_2D` followed by `compute_obs`) over an ensemble of `κ`'s, stored flat as columns of `κs`
+"""
+function run_G_ensemble(darcy, κs::AbstractMatrix)
+    N_ens = size(κs, 2) # ens size
+    nd = darcy.N_y #num obs
+    g_ens = zeros(nd, N_ens)
+    for i in 1:N_ens
+        # run the model with the current parameters, i.e., map θ to G(θ)
+        κ_i = reshape(κs[:, i], darcy.N, darcy.N) # unflatten
+        h_i = solve_Darcy_2D(darcy, κ_i) # run model
+        g_ens[:, i] = compute_obs(darcy, h_i) # observe solution
+    end
+    return g_ens
+end
+
+
+
+#=
+    return the unknow index for the grid point
+    Since zero-Dirichlet boundary conditions are imposed on  
+    all four edges, the freedoms are only on interior points
+=#
+function ind(darcy::Setup_Param{FT, IT}, ix::IT, iy::IT) where {FT <: AbstractFloat, IT <: Int}
+    return (ix - 1) + (iy - 2) * (darcy.N - 2)
+end
+
+function ind_all(darcy::Setup_Param{FT, IT}, ix::IT, iy::IT) where {FT <: AbstractFloat, IT <: Int}
+    return ix + (iy - 1) * darcy.N
+end
+
+#=
+    solve Darcy equation with finite difference method:
+    -∇(κ∇h) = f
+    with Dirichlet boundary condition, h=0 on ∂Ω
+=#
+function solve_Darcy_2D(darcy::Setup_Param{FT, IT}, κ_2d::AbstractMatrix{FT}) where {FT <: AbstractFloat, IT <: Int}
+    Δx, N = darcy.Δx, darcy.N
+
+    indx = IT[]
+    indy = IT[]
+    vals = FT[]
+
+    f_2d = darcy.f_2d
+
+    𝓒 = Δx^2
+    for iy in 2:(N - 1)
+        for ix in 2:(N - 1)
+
+            ixy = ind(darcy, ix, iy)
+
+            #top
+            if iy == N - 1
+                #ft = -(κ_2d[ix, iy] + κ_2d[ix, iy+1])/2.0 * (0 - h_2d[ix,iy])
+                push!(indx, ixy)
+                push!(indy, ixy)
+                push!(vals, (κ_2d[ix, iy] + κ_2d[ix, iy + 1]) / 2.0 / 𝓒)
+            else
+                #ft = -(κ_2d[ix, iy] + κ_2d[ix, iy+1])/2.0 * (h_2d[ix,iy+1] - h_2d[ix,iy])
+                append!(indx, [ixy, ixy])
+                append!(indy, [ixy, ind(darcy, ix, iy + 1)])
+                append!(
+                    vals,
+                    [(κ_2d[ix, iy] + κ_2d[ix, iy + 1]) / 2.0 / 𝓒, -(κ_2d[ix, iy] + κ_2d[ix, iy + 1]) / 2.0 / 𝓒],
+                )
+            end
+
+            #bottom
+            if iy == 2
+                #fb = (κ_2d[ix, iy] + κ_2d[ix, iy-1])/2.0 * (h_2d[ix,iy] - 0)
+                push!(indx, ixy)
+                push!(indy, ixy)
+                push!(vals, (κ_2d[ix, iy] + κ_2d[ix, iy - 1]) / 2.0 / 𝓒)
+            else
+                #fb = (κ_2d[ix, iy] + κ_2d[ix, iy-1])/2.0 * (h_2d[ix,iy] - h_2d[ix,iy-1])
+                append!(indx, [ixy, ixy])
+                append!(indy, [ixy, ind(darcy, ix, iy - 1)])
+                append!(
+                    vals,
+                    [(κ_2d[ix, iy] + κ_2d[ix, iy - 1]) / 2.0 / 𝓒, -(κ_2d[ix, iy] + κ_2d[ix, iy - 1]) / 2.0 / 𝓒],
+                )
+            end
+
+            #right
+            if ix == N - 1
+                #fr = -(κ_2d[ix, iy] + κ_2d[ix+1, iy])/2.0 * (0 - h_2d[ix,iy])
+                push!(indx, ixy)
+                push!(indy, ixy)
+                push!(vals, (κ_2d[ix, iy] + κ_2d[ix + 1, iy]) / 2.0 / 𝓒)
+            else
+                #fr = -(κ_2d[ix, iy] + κ_2d[ix+1, iy])/2.0 * (h_2d[ix+1,iy] - h_2d[ix,iy])
+                append!(indx, [ixy, ixy])
+                append!(indy, [ixy, ind(darcy, ix + 1, iy)])
+                append!(
+                    vals,
+                    [(κ_2d[ix, iy] + κ_2d[ix + 1, iy]) / 2.0 / 𝓒, -(κ_2d[ix, iy] + κ_2d[ix + 1, iy]) / 2.0 / 𝓒],
+                )
+            end
+
+            #left
+            if ix == 2
+                #fl = (κ_2d[ix, iy] + κ_2d[ix-1, iy])/2.0 * (h_2d[ix,iy] - 0)
+                push!(indx, ixy)
+                push!(indy, ixy)
+                push!(vals, (κ_2d[ix, iy] + κ_2d[ix - 1, iy]) / 2.0 / 𝓒)
+            else
+                #fl = (κ_2d[ix, iy] + κ_2d[ix-1, iy])/2.0 * (h_2d[ix,iy] - h_2d[ix-1,iy])
+                append!(indx, [ixy, ixy])
+                append!(indy, [ixy, ind(darcy, ix - 1, iy)])
+                append!(
+                    vals,
+                    [(κ_2d[ix, iy] + κ_2d[ix - 1, iy]) / 2.0 / 𝓒, -(κ_2d[ix, iy] + κ_2d[ix - 1, iy]) / 2.0 / 𝓒],
+                )
+            end
+
+        end
+    end
+
+
+
+    df = sparse(indx, indy, vals, (N - 2)^2, (N - 2)^2)
+    # Multithread does not support sparse matrix solver
+    h = df \ (f_2d[2:(N - 1), 2:(N - 1)])[:]
+
+    h_2d = zeros(FT, N, N)
+    h_2d[2:(N - 1), 2:(N - 1)] .= reshape(h, N - 2, N - 2)
+
+    return h_2d
+end
+
+#=
+Compute observation values
+=#
+function compute_obs(darcy::Setup_Param{FT, IT}, h_2d::AbstractMatrix{FT}) where {FT <: AbstractFloat, IT <: Int}
+    # X---X(1)---X(2) ... X(obs_N)---X
+    obs_2d = h_2d[darcy.x_locs, darcy.y_locs]
+
+    return obs_2d[:]
+end

--- a/examples/Darcy/Project.toml
+++ b/examples/Darcy/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+CalibrateEmulateSample = "95e48a1f-0bec-4818-9538-3db4340308e3"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+GaussianRandomFields = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/examples/Darcy/calibrate.jl
+++ b/examples/Darcy/calibrate.jl
@@ -45,146 +45,164 @@ rng = Random.MersenneTwister(seed)
 
 
 function main()
-# Define the spatial domain and discretization 
-dim = 2
-N, L = 80, 1.0
-pts_per_dim = LinRange(0, L, N)
-obs_ΔN = 10
+    # Define the spatial domain and discretization 
+    dim = 2
+    N, L = 80, 1.0
+    pts_per_dim = LinRange(0, L, N)
+    obs_ΔN = 10
 
-# To provide a simple test case, we assume that the true function parameter is a particular sample from the function space we set up to define our prior. More precisely we choose a value of the truth that doesnt have a vanishingly small probability under the prior defined by a probability distribution over functions; here taken as a family of Gaussian Random Fields (GRF). The function distribution is characterized by a covariance function - here a Matern kernel which assumes a level of smoothness over the samples from the distribution. We define an appropriate expansion of this distribution, here based on the Karhunen-Loeve expansion (similar to an eigenvalue-eigenfunction expansion) that is truncated to a finite number of terms, known as the degrees of freedom (`dofs`). The `dofs` define the effective dimension of the learning problem, decoupled from the spatial discretization. Explicitly, larger `dofs` may be required to represent multiscale functions, but come at an increased dimension of the parameter space and therefore a typical increase in cost and difficulty of the learning problem.
+    # To provide a simple test case, we assume that the true function parameter is a particular sample from the function space we set up to define our prior. More precisely we choose a value of the truth that doesnt have a vanishingly small probability under the prior defined by a probability distribution over functions; here taken as a family of Gaussian Random Fields (GRF). The function distribution is characterized by a covariance function - here a Matern kernel which assumes a level of smoothness over the samples from the distribution. We define an appropriate expansion of this distribution, here based on the Karhunen-Loeve expansion (similar to an eigenvalue-eigenfunction expansion) that is truncated to a finite number of terms, known as the degrees of freedom (`dofs`). The `dofs` define the effective dimension of the learning problem, decoupled from the spatial discretization. Explicitly, larger `dofs` may be required to represent multiscale functions, but come at an increased dimension of the parameter space and therefore a typical increase in cost and difficulty of the learning problem.
 
-smoothness = 1.0
-corr_length = 0.25
-dofs = 5
+    smoothness = 1.0
+    corr_length = 0.25
+    dofs = 5
 
-grf = GRF.GaussianRandomField(
-    GRF.CovarianceFunction(dim, GRF.Matern(smoothness, corr_length)),
-    GRF.KarhunenLoeve(dofs),
-    pts_per_dim,
-    pts_per_dim,
-)
+    grf = GRF.GaussianRandomField(
+        GRF.CovarianceFunction(dim, GRF.Matern(smoothness, corr_length)),
+        GRF.KarhunenLoeve(dofs),
+        pts_per_dim,
+        pts_per_dim,
+    )
 
-# We define a wrapper around the GRF, and as the permeability field must be positive we introduce a domain constraint into the function distribution. Henceforth, the GRF is interfaced in the same manner as any other parameter distribution with regards to interface.
-pkg = GRFJL()
-distribution = GaussianRandomFieldInterface(grf, pkg) # our wrapper from EKP
-domain_constraint = bounded_below(0) # make κ positive
-pd = ParameterDistribution(Dict("distribution" => distribution, "name" => "kappa", "constraint" => domain_constraint)) # the fully constrained parameter distribution
+    # We define a wrapper around the GRF, and as the permeability field must be positive we introduce a domain constraint into the function distribution. Henceforth, the GRF is interfaced in the same manner as any other parameter distribution with regards to interface.
+    pkg = GRFJL()
+    distribution = GaussianRandomFieldInterface(grf, pkg) # our wrapper from EKP
+    domain_constraint = bounded_below(0) # make κ positive
+    pd = ParameterDistribution(
+        Dict("distribution" => distribution, "name" => "kappa", "constraint" => domain_constraint),
+    ) # the fully constrained parameter distribution
 
-# Now we have a function distribution, we sample a reasonably high-probability value from this distribution as a true value (here all degrees of freedom set with `u_{\mathrm{true}} = -0.5`). We use the EKP transform function to build the corresponding instance of the ``\kappa_{\mathrm{true}}``.
-u_true = -1.5 * ones(dofs, 1) # the truth parameter
-println("True coefficients: ")
-println(u_true)
-κ_true = transform_unconstrained_to_constrained(pd, u_true) # builds and constrains the function.  
-κ_true = reshape(κ_true, N, N)
+    # Now we have a function distribution, we sample a reasonably high-probability value from this distribution as a true value (here all degrees of freedom set with `u_{\mathrm{true}} = -0.5`). We use the EKP transform function to build the corresponding instance of the ``\kappa_{\mathrm{true}}``.
+    u_true = -1.5 * ones(dofs, 1) # the truth parameter
+    println("True coefficients: ")
+    println(u_true)
+    κ_true = transform_unconstrained_to_constrained(pd, u_true) # builds and constrains the function.  
+    κ_true = reshape(κ_true, N, N)
 
-# Now we generate the data sample for the truth in a perfect model setting by evaluating the the model here, and observing it by subsampling in each dimension every `obs_ΔN` points, and add some observational noise
-darcy = Setup_Param(pts_per_dim, obs_ΔN, κ_true)
-println(" Number of observation points: $(darcy.N_y)")
-h_2d_true = solve_Darcy_2D(darcy, κ_true)
-y_noiseless = compute_obs(darcy, h_2d_true)
-obs_noise_cov = 0.05^2 * I(length(y_noiseless)) * (maximum(y_noiseless) - minimum(y_noiseless))
-truth_sample = vec(y_noiseless + rand(rng, MvNormal(zeros(length(y_noiseless)), obs_noise_cov)))
-
-
-# Now we set up the Bayesian inversion algorithm. The prior we have already defined to construct our truth
-prior = pd
+    # Now we generate the data sample for the truth in a perfect model setting by evaluating the the model here, and observing it by subsampling in each dimension every `obs_ΔN` points, and add some observational noise
+    darcy = Setup_Param(pts_per_dim, obs_ΔN, κ_true)
+    println(" Number of observation points: $(darcy.N_y)")
+    h_2d_true = solve_Darcy_2D(darcy, κ_true)
+    y_noiseless = compute_obs(darcy, h_2d_true)
+    obs_noise_cov = 0.05^2 * I(length(y_noiseless)) * (maximum(y_noiseless) - minimum(y_noiseless))
+    truth_sample = vec(y_noiseless + rand(rng, MvNormal(zeros(length(y_noiseless)), obs_noise_cov)))
 
 
-# We define some algorithm parameters, here we take ensemble members larger than the dimension of the parameter space
-N_ens = 50 # number of ensemble members
-N_iter = 5 # number of EKI iterations
+    # Now we set up the Bayesian inversion algorithm. The prior we have already defined to construct our truth
+    prior = pd
 
-# We sample the initial ensemble from the prior, and create the EKP object as an EKI algorithm using the `Inversion()` keyword
-initial_params = construct_initial_ensemble(rng, prior, N_ens)
-ekiobj = EKP.EnsembleKalmanProcess(initial_params, truth_sample, obs_noise_cov, Inversion())
 
-# We perform the inversion loop. Remember that within calls to `get_ϕ_final` the EKP transformations are applied, thus the ensemble that is returned will be the positively-bounded permeability field evaluated at all the discretization points. 
-println("Begin inversion")
-err = []
-final_it = [N_iter]
-for i in 1:N_iter
-    params_i = get_ϕ_final(prior, ekiobj)
-    g_ens = run_G_ensemble(darcy, params_i)
-    terminate = EKP.update_ensemble!(ekiobj, g_ens)
-    push!(err, get_error(ekiobj)[end]) #mean((params_true - mean(params_i,dims=2)).^2)
-    println("Iteration: " * string(i) * ", Error: " * string(err[i]))
-    if !isnothing(terminate)
-        final_it[1] = i - 1
-        break
+    # We define some algorithm parameters, here we take ensemble members larger than the dimension of the parameter space
+    N_ens = 50 # number of ensemble members
+    N_iter = 5 # number of EKI iterations
+
+    # We sample the initial ensemble from the prior, and create the EKP object as an EKI algorithm using the `Inversion()` keyword
+    initial_params = construct_initial_ensemble(rng, prior, N_ens)
+    ekiobj = EKP.EnsembleKalmanProcess(initial_params, truth_sample, obs_noise_cov, Inversion())
+
+    # We perform the inversion loop. Remember that within calls to `get_ϕ_final` the EKP transformations are applied, thus the ensemble that is returned will be the positively-bounded permeability field evaluated at all the discretization points. 
+    println("Begin inversion")
+    err = []
+    final_it = [N_iter]
+    for i in 1:N_iter
+        params_i = get_ϕ_final(prior, ekiobj)
+        g_ens = run_G_ensemble(darcy, params_i)
+        terminate = EKP.update_ensemble!(ekiobj, g_ens)
+        push!(err, get_error(ekiobj)[end]) #mean((params_true - mean(params_i,dims=2)).^2)
+        println("Iteration: " * string(i) * ", Error: " * string(err[i]))
+        if !isnothing(terminate)
+            final_it[1] = i - 1
+            break
+        end
     end
-end
-n_iter = final_it[1]
-# We plot first the prior ensemble mean and pointwise variance of the permeability field, and also the pressure field solved with the ensemble mean. Each ensemble member is stored as a column and therefore for uses such as plotting one needs to reshape to the desired dimension.
-if PLOT_FLAG
-    gr(size = (1500, 400), legend = false)
-    prior_κ_ens = get_ϕ(prior, ekiobj, 1)
-    κ_ens_mean = reshape(mean(prior_κ_ens, dims = 2), N, N)
-    p1 = contour(pts_per_dim, pts_per_dim, κ_ens_mean', fill = true, levels = 15, title = "kappa mean", colorbar = true)
-    κ_ens_ptw_var = reshape(var(prior_κ_ens, dims = 2), N, N)
-    p2 = contour(
-        pts_per_dim,
-        pts_per_dim,
-        κ_ens_ptw_var',
-        fill = true,
-        levels = 15,
-        title = "kappa var",
-        colorbar = true,
-    )
-    h_2d = solve_Darcy_2D(darcy, κ_ens_mean)
-    p3 = contour(pts_per_dim, pts_per_dim, h_2d', fill = true, levels = 15, title = "pressure", colorbar = true)
-    l = @layout [a b c]
-    plt = plot(p1, p2, p3, layout = l)
-    savefig(plt, joinpath(fig_save_directory, "output_prior.png")) # pre update
+    n_iter = final_it[1]
+    # We plot first the prior ensemble mean and pointwise variance of the permeability field, and also the pressure field solved with the ensemble mean. Each ensemble member is stored as a column and therefore for uses such as plotting one needs to reshape to the desired dimension.
+    if PLOT_FLAG
+        gr(size = (1500, 400), legend = false)
+        prior_κ_ens = get_ϕ(prior, ekiobj, 1)
+        κ_ens_mean = reshape(mean(prior_κ_ens, dims = 2), N, N)
+        p1 = contour(
+            pts_per_dim,
+            pts_per_dim,
+            κ_ens_mean',
+            fill = true,
+            levels = 15,
+            title = "kappa mean",
+            colorbar = true,
+        )
+        κ_ens_ptw_var = reshape(var(prior_κ_ens, dims = 2), N, N)
+        p2 = contour(
+            pts_per_dim,
+            pts_per_dim,
+            κ_ens_ptw_var',
+            fill = true,
+            levels = 15,
+            title = "kappa var",
+            colorbar = true,
+        )
+        h_2d = solve_Darcy_2D(darcy, κ_ens_mean)
+        p3 = contour(pts_per_dim, pts_per_dim, h_2d', fill = true, levels = 15, title = "pressure", colorbar = true)
+        l = @layout [a b c]
+        plt = plot(p1, p2, p3, layout = l)
+        savefig(plt, joinpath(fig_save_directory, "output_prior.png")) # pre update
 
-end
+    end
 
-# Now we plot the final ensemble mean and pointwise variance of the permeability field, and also the pressure field solved with the ensemble mean.
-if PLOT_FLAG
-    gr(size = (1500, 400), legend = false)
-    final_κ_ens = get_ϕ_final(prior, ekiobj) # the `ϕ` indicates that the `params_i` are in the constrained space
-    κ_ens_mean = reshape(mean(final_κ_ens, dims = 2), N, N)
-    p1 = contour(pts_per_dim, pts_per_dim, κ_ens_mean', fill = true, levels = 15, title = "kappa mean", colorbar = true)
-    κ_ens_ptw_var = reshape(var(final_κ_ens, dims = 2), N, N)
-    p2 = contour(
-        pts_per_dim,
-        pts_per_dim,
-        κ_ens_ptw_var',
-        fill = true,
-        levels = 15,
-        title = "kappa var",
-        colorbar = true,
-    )
-    h_2d = solve_Darcy_2D(darcy, κ_ens_mean)
-    p3 = contour(pts_per_dim, pts_per_dim, h_2d', fill = true, levels = 15, title = "pressure", colorbar = true)
-    l = @layout [a b c]
-    plt = plot(p1, p2, p3; layout = l)
-    savefig(plt, joinpath(fig_save_directory, "output_it_" * string(n_iter) * ".png")) # pre update
+    # Now we plot the final ensemble mean and pointwise variance of the permeability field, and also the pressure field solved with the ensemble mean.
+    if PLOT_FLAG
+        gr(size = (1500, 400), legend = false)
+        final_κ_ens = get_ϕ_final(prior, ekiobj) # the `ϕ` indicates that the `params_i` are in the constrained space
+        κ_ens_mean = reshape(mean(final_κ_ens, dims = 2), N, N)
+        p1 = contour(
+            pts_per_dim,
+            pts_per_dim,
+            κ_ens_mean',
+            fill = true,
+            levels = 15,
+            title = "kappa mean",
+            colorbar = true,
+        )
+        κ_ens_ptw_var = reshape(var(final_κ_ens, dims = 2), N, N)
+        p2 = contour(
+            pts_per_dim,
+            pts_per_dim,
+            κ_ens_ptw_var',
+            fill = true,
+            levels = 15,
+            title = "kappa var",
+            colorbar = true,
+        )
+        h_2d = solve_Darcy_2D(darcy, κ_ens_mean)
+        p3 = contour(pts_per_dim, pts_per_dim, h_2d', fill = true, levels = 15, title = "pressure", colorbar = true)
+        l = @layout [a b c]
+        plt = plot(p1, p2, p3; layout = l)
+        savefig(plt, joinpath(fig_save_directory, "output_it_" * string(n_iter) * ".png")) # pre update
 
-end
-println("Final coefficients (ensemble mean):")
-println(get_u_mean_final(ekiobj))
+    end
+    println("Final coefficients (ensemble mean):")
+    println(get_u_mean_final(ekiobj))
 
-# We can compare this with the true permeability and pressure field: 
-if PLOT_FLAG
-    gr(size = (1000, 400), legend = false)
-    p1 = contour(pts_per_dim, pts_per_dim, κ_true', fill = true, levels = 15, title = "kappa true", colorbar = true)
-    p2 = contour(
-        pts_per_dim,
-        pts_per_dim,
-        h_2d_true',
-        fill = true,
-        levels = 15,
-        title = "pressure true",
-        colorbar = true,
-    )
-    l = @layout [a b]
-    plt = plot(p1, p2, layout = l)
-    savefig(plt, joinpath(fig_save_directory, "output_true.png"))
-end
+    # We can compare this with the true permeability and pressure field: 
+    if PLOT_FLAG
+        gr(size = (1000, 400), legend = false)
+        p1 = contour(pts_per_dim, pts_per_dim, κ_true', fill = true, levels = 15, title = "kappa true", colorbar = true)
+        p2 = contour(
+            pts_per_dim,
+            pts_per_dim,
+            h_2d_true',
+            fill = true,
+            levels = 15,
+            title = "pressure true",
+            colorbar = true,
+        )
+        l = @layout [a b]
+        plt = plot(p1, p2, layout = l)
+        savefig(plt, joinpath(fig_save_directory, "output_true.png"))
+    end
 
-# Finally the data is saved
-u_stored = get_u(ekiobj, return_array = false)
-g_stored = get_g(ekiobj, return_array = false)
+    # Finally the data is saved
+    u_stored = get_u(ekiobj, return_array = false)
+    g_stored = get_g(ekiobj, return_array = false)
 
     save(
         joinpath(data_save_directory, "calibrate_results.jld2"),
@@ -201,7 +219,7 @@ g_stored = get_g(ekiobj, return_array = false)
         "truth_input_constrained", # the discrete true parameter field
         κ_true,
         "truth_input_unconstrained", # the discrete true KL coefficients
-        u_true, 
+        u_true,
     )
 end
 

--- a/examples/Darcy/calibrate.jl
+++ b/examples/Darcy/calibrate.jl
@@ -49,12 +49,12 @@ function main()
     dim = 2
     N, L = 80, 1.0
     pts_per_dim = LinRange(0, L, N)
-    obs_ΔN = 20
+    obs_ΔN = 10
 
     # To provide a simple test case, we assume that the true function parameter is a particular sample from the function space we set up to define our prior. More precisely we choose a value of the truth that doesnt have a vanishingly small probability under the prior defined by a probability distribution over functions; here taken as a family of Gaussian Random Fields (GRF). The function distribution is characterized by a covariance function - here a Matern kernel which assumes a level of smoothness over the samples from the distribution. We define an appropriate expansion of this distribution, here based on the Karhunen-Loeve expansion (similar to an eigenvalue-eigenfunction expansion) that is truncated to a finite number of terms, known as the degrees of freedom (`dofs`). The `dofs` define the effective dimension of the learning problem, decoupled from the spatial discretization. Explicitly, larger `dofs` may be required to represent multiscale functions, but come at an increased dimension of the parameter space and therefore a typical increase in cost and difficulty of the learning problem.
 
-    smoothness = 1.0
-    corr_length = 0.25
+    smoothness = 10
+    corr_length = 0.25 # 0.25
     dofs = 6
 
     grf = GRF.GaussianRandomField(
@@ -84,7 +84,7 @@ function main()
     println(" Number of observation points: $(darcy.N_y)")
     h_2d_true = solve_Darcy_2D(darcy, κ_true)
     y_noiseless = compute_obs(darcy, h_2d_true)
-    obs_noise_cov = 0.2^2 * I(length(y_noiseless)) * (maximum(y_noiseless) - minimum(y_noiseless))
+    obs_noise_cov = 0.25^2 * I(length(y_noiseless)) * (maximum(y_noiseless) - minimum(y_noiseless))
     truth_sample = vec(y_noiseless + rand(rng, MvNormal(zeros(length(y_noiseless)), obs_noise_cov)))
 
 

--- a/examples/Darcy/calibrate.jl
+++ b/examples/Darcy/calibrate.jl
@@ -53,10 +53,10 @@ function main()
 
     # To provide a simple test case, we assume that the true function parameter is a particular sample from the function space we set up to define our prior. More precisely we choose a value of the truth that doesnt have a vanishingly small probability under the prior defined by a probability distribution over functions; here taken as a family of Gaussian Random Fields (GRF). The function distribution is characterized by a covariance function - here a Matern kernel which assumes a level of smoothness over the samples from the distribution. We define an appropriate expansion of this distribution, here based on the Karhunen-Loeve expansion (similar to an eigenvalue-eigenfunction expansion) that is truncated to a finite number of terms, known as the degrees of freedom (`dofs`). The `dofs` define the effective dimension of the learning problem, decoupled from the spatial discretization. Explicitly, larger `dofs` may be required to represent multiscale functions, but come at an increased dimension of the parameter space and therefore a typical increase in cost and difficulty of the learning problem.
 
-    smoothness = 10
-    corr_length = 0.25 # 0.25
-    dofs = 6
-
+    smoothness = 0.1
+    corr_length = 1.0 
+    dofs = 5
+    
     grf = GRF.GaussianRandomField(
         GRF.CovarianceFunction(dim, GRF.Matern(smoothness, corr_length)),
         GRF.KarhunenLoeve(dofs),
@@ -73,7 +73,7 @@ function main()
     ) # the fully constrained parameter distribution
 
     # Now we have a function distribution, we sample a reasonably high-probability value from this distribution as a true value (here all degrees of freedom set with `u_{\mathrm{true}} = -0.5`). We use the EKP transform function to build the corresponding instance of the ``\kappa_{\mathrm{true}}``.
-    u_true = -1.5 * ones(dofs, 1) # the truth parameter
+    u_true = sign.(randn(dofs, 1)) # the truth parameter
     println("True coefficients: ")
     println(u_true)
     κ_true = transform_unconstrained_to_constrained(pd, u_true) # builds and constrains the function.  

--- a/examples/Darcy/calibrate.jl
+++ b/examples/Darcy/calibrate.jl
@@ -54,9 +54,9 @@ function main()
     # To provide a simple test case, we assume that the true function parameter is a particular sample from the function space we set up to define our prior. More precisely we choose a value of the truth that doesnt have a vanishingly small probability under the prior defined by a probability distribution over functions; here taken as a family of Gaussian Random Fields (GRF). The function distribution is characterized by a covariance function - here a Matern kernel which assumes a level of smoothness over the samples from the distribution. We define an appropriate expansion of this distribution, here based on the Karhunen-Loeve expansion (similar to an eigenvalue-eigenfunction expansion) that is truncated to a finite number of terms, known as the degrees of freedom (`dofs`). The `dofs` define the effective dimension of the learning problem, decoupled from the spatial discretization. Explicitly, larger `dofs` may be required to represent multiscale functions, but come at an increased dimension of the parameter space and therefore a typical increase in cost and difficulty of the learning problem.
 
     smoothness = 0.1
-    corr_length = 1.0 
+    corr_length = 1.0
     dofs = 5
-    
+
     grf = GRF.GaussianRandomField(
         GRF.CovarianceFunction(dim, GRF.Matern(smoothness, corr_length)),
         GRF.KarhunenLoeve(dofs),

--- a/examples/Darcy/calibrate.jl
+++ b/examples/Darcy/calibrate.jl
@@ -1,0 +1,208 @@
+# # [Learning the Pearmibility field in a Darcy flow from noisy sparse observations] 
+
+# In this example we hope to illustrate function learning. One may wish to use function learning in cases where the underlying parameter of interest is actual a finite-dimensional approximation (e.g. spatial discretization) of some "true" function. Treating such an object directly will lead to increasingly high-dimensional learning problems as the spatial resolution is increased, resulting in poor computational scaling and increasingly ill-posed inverse problems. Treating the object as a discretized function from a function space, one can learn coefficients not in the standard basis, but instead in a basis of this function space, it is commonly the case that functions will have relatively low effective dimension, and will be depend only on the spatial discretization due to discretization error, that should vanish as resolution is increased. 
+
+# We will solve for an unknown permeability field ``\kappa`` governing the pressure field of a Darcy flow on a square 2D domain. To learn about the permeability we shall take few pointwise measurements of the solved pressure field within the domain. The forward solver is a simple finite difference scheme taken and modified from code [here](https://github.com/Zhengyu-Huang/InverseProblems.jl/blob/master/Fluid/Darcy-2D.jl). 
+
+# First we load standard packages
+using LinearAlgebra
+using Distributions
+using Random
+using JLD2
+
+# the package to define the function distributions
+import GaussianRandomFields # we wrap this so we don't want to use "using"
+const GRF = GaussianRandomFields
+
+# and finally the EKP packages
+using CalibrateEmulateSample
+using CalibrateEmulateSample.EnsembleKalmanProcesses
+using CalibrateEmulateSample.EnsembleKalmanProcesses.ParameterDistributions
+const EKP = CalibrateEmulateSample.EnsembleKalmanProcesses
+
+# We include the forward solver here
+include("GModel.jl")
+
+# Then link some outputs for figures and plotting
+fig_save_directory = joinpath(@__DIR__, "output")
+data_save_directory = joinpath(@__DIR__, "output")
+if !isdir(fig_save_directory)
+    mkdir(fig_save_directory)
+end
+if !isdir(data_save_directory)
+    mkdir(data_save_directory)
+end# TOML interface for fitting parameters of a sinusoid
+
+PLOT_FLAG = true
+if PLOT_FLAG
+    using Plots
+    @info "Plotting enabled, this will reduce code performance. Figures stored in $fig_save_directory"
+end
+
+# Set a random seed.
+seed = 100234
+rng = Random.MersenneTwister(seed)
+
+
+function main()
+# Define the spatial domain and discretization 
+dim = 2
+N, L = 80, 1.0
+pts_per_dim = LinRange(0, L, N)
+obs_ΔN = 10
+
+# To provide a simple test case, we assume that the true function parameter is a particular sample from the function space we set up to define our prior. More precisely we choose a value of the truth that doesnt have a vanishingly small probability under the prior defined by a probability distribution over functions; here taken as a family of Gaussian Random Fields (GRF). The function distribution is characterized by a covariance function - here a Matern kernel which assumes a level of smoothness over the samples from the distribution. We define an appropriate expansion of this distribution, here based on the Karhunen-Loeve expansion (similar to an eigenvalue-eigenfunction expansion) that is truncated to a finite number of terms, known as the degrees of freedom (`dofs`). The `dofs` define the effective dimension of the learning problem, decoupled from the spatial discretization. Explicitly, larger `dofs` may be required to represent multiscale functions, but come at an increased dimension of the parameter space and therefore a typical increase in cost and difficulty of the learning problem.
+
+smoothness = 1.0
+corr_length = 0.25
+dofs = 5
+
+grf = GRF.GaussianRandomField(
+    GRF.CovarianceFunction(dim, GRF.Matern(smoothness, corr_length)),
+    GRF.KarhunenLoeve(dofs),
+    pts_per_dim,
+    pts_per_dim,
+)
+
+# We define a wrapper around the GRF, and as the permeability field must be positive we introduce a domain constraint into the function distribution. Henceforth, the GRF is interfaced in the same manner as any other parameter distribution with regards to interface.
+pkg = GRFJL()
+distribution = GaussianRandomFieldInterface(grf, pkg) # our wrapper from EKP
+domain_constraint = bounded_below(0) # make κ positive
+pd = ParameterDistribution(Dict("distribution" => distribution, "name" => "kappa", "constraint" => domain_constraint)) # the fully constrained parameter distribution
+
+# Now we have a function distribution, we sample a reasonably high-probability value from this distribution as a true value (here all degrees of freedom set with `u_{\mathrm{true}} = -0.5`). We use the EKP transform function to build the corresponding instance of the ``\kappa_{\mathrm{true}}``.
+u_true = -1.5 * ones(dofs, 1) # the truth parameter
+println("True coefficients: ")
+println(u_true)
+κ_true = transform_unconstrained_to_constrained(pd, u_true) # builds and constrains the function.  
+κ_true = reshape(κ_true, N, N)
+
+# Now we generate the data sample for the truth in a perfect model setting by evaluating the the model here, and observing it by subsampling in each dimension every `obs_ΔN` points, and add some observational noise
+darcy = Setup_Param(pts_per_dim, obs_ΔN, κ_true)
+println(" Number of observation points: $(darcy.N_y)")
+h_2d_true = solve_Darcy_2D(darcy, κ_true)
+y_noiseless = compute_obs(darcy, h_2d_true)
+obs_noise_cov = 0.05^2 * I(length(y_noiseless)) * (maximum(y_noiseless) - minimum(y_noiseless))
+truth_sample = vec(y_noiseless + rand(rng, MvNormal(zeros(length(y_noiseless)), obs_noise_cov)))
+
+
+# Now we set up the Bayesian inversion algorithm. The prior we have already defined to construct our truth
+prior = pd
+
+
+# We define some algorithm parameters, here we take ensemble members larger than the dimension of the parameter space
+N_ens = 50 # number of ensemble members
+N_iter = 5 # number of EKI iterations
+
+# We sample the initial ensemble from the prior, and create the EKP object as an EKI algorithm using the `Inversion()` keyword
+initial_params = construct_initial_ensemble(rng, prior, N_ens)
+ekiobj = EKP.EnsembleKalmanProcess(initial_params, truth_sample, obs_noise_cov, Inversion())
+
+# We perform the inversion loop. Remember that within calls to `get_ϕ_final` the EKP transformations are applied, thus the ensemble that is returned will be the positively-bounded permeability field evaluated at all the discretization points. 
+println("Begin inversion")
+err = []
+final_it = [N_iter]
+for i in 1:N_iter
+    params_i = get_ϕ_final(prior, ekiobj)
+    g_ens = run_G_ensemble(darcy, params_i)
+    terminate = EKP.update_ensemble!(ekiobj, g_ens)
+    push!(err, get_error(ekiobj)[end]) #mean((params_true - mean(params_i,dims=2)).^2)
+    println("Iteration: " * string(i) * ", Error: " * string(err[i]))
+    if !isnothing(terminate)
+        final_it[1] = i - 1
+        break
+    end
+end
+n_iter = final_it[1]
+# We plot first the prior ensemble mean and pointwise variance of the permeability field, and also the pressure field solved with the ensemble mean. Each ensemble member is stored as a column and therefore for uses such as plotting one needs to reshape to the desired dimension.
+if PLOT_FLAG
+    gr(size = (1500, 400), legend = false)
+    prior_κ_ens = get_ϕ(prior, ekiobj, 1)
+    κ_ens_mean = reshape(mean(prior_κ_ens, dims = 2), N, N)
+    p1 = contour(pts_per_dim, pts_per_dim, κ_ens_mean', fill = true, levels = 15, title = "kappa mean", colorbar = true)
+    κ_ens_ptw_var = reshape(var(prior_κ_ens, dims = 2), N, N)
+    p2 = contour(
+        pts_per_dim,
+        pts_per_dim,
+        κ_ens_ptw_var',
+        fill = true,
+        levels = 15,
+        title = "kappa var",
+        colorbar = true,
+    )
+    h_2d = solve_Darcy_2D(darcy, κ_ens_mean)
+    p3 = contour(pts_per_dim, pts_per_dim, h_2d', fill = true, levels = 15, title = "pressure", colorbar = true)
+    l = @layout [a b c]
+    plt = plot(p1, p2, p3, layout = l)
+    savefig(plt, joinpath(fig_save_directory, "output_prior.png")) # pre update
+
+end
+
+# Now we plot the final ensemble mean and pointwise variance of the permeability field, and also the pressure field solved with the ensemble mean.
+if PLOT_FLAG
+    gr(size = (1500, 400), legend = false)
+    final_κ_ens = get_ϕ_final(prior, ekiobj) # the `ϕ` indicates that the `params_i` are in the constrained space
+    κ_ens_mean = reshape(mean(final_κ_ens, dims = 2), N, N)
+    p1 = contour(pts_per_dim, pts_per_dim, κ_ens_mean', fill = true, levels = 15, title = "kappa mean", colorbar = true)
+    κ_ens_ptw_var = reshape(var(final_κ_ens, dims = 2), N, N)
+    p2 = contour(
+        pts_per_dim,
+        pts_per_dim,
+        κ_ens_ptw_var',
+        fill = true,
+        levels = 15,
+        title = "kappa var",
+        colorbar = true,
+    )
+    h_2d = solve_Darcy_2D(darcy, κ_ens_mean)
+    p3 = contour(pts_per_dim, pts_per_dim, h_2d', fill = true, levels = 15, title = "pressure", colorbar = true)
+    l = @layout [a b c]
+    plt = plot(p1, p2, p3; layout = l)
+    savefig(plt, joinpath(fig_save_directory, "output_it_" * string(n_iter) * ".png")) # pre update
+
+end
+println("Final coefficients (ensemble mean):")
+println(get_u_mean_final(ekiobj))
+
+# We can compare this with the true permeability and pressure field: 
+if PLOT_FLAG
+    gr(size = (1000, 400), legend = false)
+    p1 = contour(pts_per_dim, pts_per_dim, κ_true', fill = true, levels = 15, title = "kappa true", colorbar = true)
+    p2 = contour(
+        pts_per_dim,
+        pts_per_dim,
+        h_2d_true',
+        fill = true,
+        levels = 15,
+        title = "pressure true",
+        colorbar = true,
+    )
+    l = @layout [a b]
+    plt = plot(p1, p2, layout = l)
+    savefig(plt, joinpath(fig_save_directory, "output_true.png"))
+end
+
+# Finally the data is saved
+u_stored = get_u(ekiobj, return_array = false)
+g_stored = get_g(ekiobj, return_array = false)
+
+    save(
+        joinpath(data_save_directory, "calibrate_results.jld2"),
+        "inputs",
+        u_stored,
+        "outputs",
+        g_stored,
+        "prior",
+        prior,
+        "eki",
+        ekiobj,
+        "truth_sample",
+        truth_sample, #data
+        "truth_input_constrained", # the discrete true parameter field
+        κ_true,
+        "truth_input_unconstrained", # the discrete true KL coefficients
+        u_true, 
+    )
+end
+
+main()

--- a/examples/Darcy/calibrate.jl
+++ b/examples/Darcy/calibrate.jl
@@ -49,13 +49,13 @@ function main()
     dim = 2
     N, L = 80, 1.0
     pts_per_dim = LinRange(0, L, N)
-    obs_ΔN = 10
+    obs_ΔN = 20
 
     # To provide a simple test case, we assume that the true function parameter is a particular sample from the function space we set up to define our prior. More precisely we choose a value of the truth that doesnt have a vanishingly small probability under the prior defined by a probability distribution over functions; here taken as a family of Gaussian Random Fields (GRF). The function distribution is characterized by a covariance function - here a Matern kernel which assumes a level of smoothness over the samples from the distribution. We define an appropriate expansion of this distribution, here based on the Karhunen-Loeve expansion (similar to an eigenvalue-eigenfunction expansion) that is truncated to a finite number of terms, known as the degrees of freedom (`dofs`). The `dofs` define the effective dimension of the learning problem, decoupled from the spatial discretization. Explicitly, larger `dofs` may be required to represent multiscale functions, but come at an increased dimension of the parameter space and therefore a typical increase in cost and difficulty of the learning problem.
 
     smoothness = 1.0
     corr_length = 0.25
-    dofs = 5
+    dofs = 6
 
     grf = GRF.GaussianRandomField(
         GRF.CovarianceFunction(dim, GRF.Matern(smoothness, corr_length)),
@@ -84,7 +84,7 @@ function main()
     println(" Number of observation points: $(darcy.N_y)")
     h_2d_true = solve_Darcy_2D(darcy, κ_true)
     y_noiseless = compute_obs(darcy, h_2d_true)
-    obs_noise_cov = 0.05^2 * I(length(y_noiseless)) * (maximum(y_noiseless) - minimum(y_noiseless))
+    obs_noise_cov = 0.2^2 * I(length(y_noiseless)) * (maximum(y_noiseless) - minimum(y_noiseless))
     truth_sample = vec(y_noiseless + rand(rng, MvNormal(zeros(length(y_noiseless)), obs_noise_cov)))
 
 
@@ -93,7 +93,7 @@ function main()
 
 
     # We define some algorithm parameters, here we take ensemble members larger than the dimension of the parameter space
-    N_ens = 50 # number of ensemble members
+    N_ens = 30 # number of ensemble members
     N_iter = 5 # number of EKI iterations
 
     # We sample the initial ensemble from the prior, and create the EKP object as an EKI algorithm using the `Inversion()` keyword

--- a/examples/Darcy/emulate_sample.jl
+++ b/examples/Darcy/emulate_sample.jl
@@ -161,6 +161,7 @@ function main()
         constrained_posterior_samples =
             transform_unconstrained_to_constrained(prior, posterior_samples[:, plot_sample_id])
 
+        gr(size = (1500, 400), legend = false)
         κ_ens_mean = reshape(mean(constrained_posterior_samples, dims = 2), N, N)
         p1 = contour(
             pts_per_dim,

--- a/examples/Darcy/emulate_sample.jl
+++ b/examples/Darcy/emulate_sample.jl
@@ -34,11 +34,11 @@ function main()
         println("case: ", case)
         min_iter = 1
         max_iter = 5 # number of EKP iterations to use data from is at most this
-        
+
         exp_name = "darcy"
         rng_seed = 940284
         rng = Random.MersenneTwister(rng_seed)
-        
+
         # loading relevant data
         homedir = pwd()
         println(homedir)
@@ -64,7 +64,7 @@ function main()
         N, L = 80, 1.0
         pts_per_dim = LinRange(0, L, N)
         obs_ΔN = 10
-        darcy = Setup_Param(pts_per_dim, obs_ΔN, truth_params_constrained )
+        darcy = Setup_Param(pts_per_dim, obs_ΔN, truth_params_constrained)
 
 
         n_params = length(truth_params) # "input dim"
@@ -104,7 +104,7 @@ function main()
             retained_svd_frac = retained_svd_frac,
             decorrelate = decorrelate,
         )
-        optimize_hyperparameters!(emulator, kernbounds = [fill(-1e2, n_params+1), fill(1e2, n_params+1)])
+        optimize_hyperparameters!(emulator, kernbounds = [fill(-1e2, n_params + 1), fill(1e2, n_params + 1)])
 
         # Check how well the Gaussian Process regression predicts on the
         # true parameters
@@ -134,7 +134,7 @@ function main()
 
         # First let's run a short chain to determine a good step size
         mcmc = MCMCWrapper(RWMHSampling(), truth_sample, prior, emulator; init_params = u0)
-#        mcmc = MCMCWrapper(pCNMHSampling(), truth_sample, prior, emulator; init_params = u0)
+        #        mcmc = MCMCWrapper(pCNMHSampling(), truth_sample, prior, emulator; init_params = u0)
         new_step = optimize_stepsize(mcmc; init_stepsize = 0.1, N = 2000, discard_initial = 0)
 
         # Now begin the actual MCMC
@@ -185,7 +185,7 @@ function main()
 
         h_2d = solve_Darcy_2D(darcy, κ_ens_mean)
         p3 = contour(pts_per_dim, pts_per_dim, h_2d', fill = true, levels = 15, title = "pressure", colorbar = true)
-        
+
         l = @layout [a b c]
         plt = plot(p1, p2, p3, layout = l)
         savefig(plt, joinpath(data_save_directory, "$(case)_posterior_pointwise_uq.png"))

--- a/examples/Darcy/emulate_sample.jl
+++ b/examples/Darcy/emulate_sample.jl
@@ -147,10 +147,10 @@ function main()
 
         param_names = get_name(posterior)
 
-        posterior_samples = reduce(vcat,[get_distribution(posterior)[name] for name in get_name(posterior)]) #samples are columns of this matrix
+        posterior_samples = reduce(vcat, [get_distribution(posterior)[name] for name in get_name(posterior)]) #samples are columns of this matrix
 
         #... plot etc
-        
+
         # Save data
         save(
             joinpath(data_save_directory, "posterior.jld2"),

--- a/examples/Darcy/emulate_sample.jl
+++ b/examples/Darcy/emulate_sample.jl
@@ -147,11 +147,10 @@ function main()
 
         param_names = get_name(posterior)
 
-        posterior_samples = vcat([get_distribution(posterior)[name] for name in get_name(posterior)]...) #samples are columns
-        constrained_posterior_samples =
-            mapslices(x -> transform_unconstrained_to_constrained(posterior, x), posterior_samples, dims = 1)
+        posterior_samples = reduce(vcat,[get_distribution(posterior)[name] for name in get_name(posterior)]) #samples are columns of this matrix
 
-
+        #... plot etc
+        
         # Save data
         save(
             joinpath(data_save_directory, "posterior.jld2"),

--- a/examples/Darcy/emulate_sample.jl
+++ b/examples/Darcy/emulate_sample.jl
@@ -39,7 +39,7 @@ function main()
             "cov_sample_multiplier" => 0.5,
             "n_iteration" => 20,
             "n_ensemble" => 120,
-            "localization" => Localizers.SECNice(1000,0.1,1.0),
+            "localization" => Localizers.SECNice(1000, 0.1, 1.0),
         )
         # we do not want termination, as our priors have relatively little interpretation
 
@@ -90,12 +90,9 @@ function main()
         # choice of machine-learning tool in the emulation stage
         nugget = 1e-12
         if case == "GP"
-#            gppackage = Emulators.SKLJL()
+            #            gppackage = Emulators.SKLJL()
             gppackage = Emulators.GPJL()
-            mlt = GaussianProcess(
-                gppackage;
-                noise_learn = false,
-            )
+            mlt = GaussianProcess(gppackage; noise_learn = false)
         elseif case ∈ ["RF-vector-svd-nonsep"]
             kernel_structure = NonseparableKernel(LowRankFactor(1, nugget))
             n_features = 100

--- a/examples/Darcy/emulate_sample.jl
+++ b/examples/Darcy/emulate_sample.jl
@@ -1,0 +1,203 @@
+# Import modules
+include(joinpath(@__DIR__, "..", "ci", "linkfig.jl"))
+
+# Import modules
+using Distributions  # probability distributions and associated functions
+using LinearAlgebra
+ENV["GKSwstype"] = "100"
+using Plots
+using Random
+using JLD2
+
+# CES 
+using CalibrateEmulateSample.Emulators
+using CalibrateEmulateSample.MarkovChainMonteCarlo
+using CalibrateEmulateSample.Utilities
+using CalibrateEmulateSample.EnsembleKalmanProcesses
+using CalibrateEmulateSample.EnsembleKalmanProcesses.Localizers
+using CalibrateEmulateSample.ParameterDistributions
+using CalibrateEmulateSample.DataContainers
+
+function main()
+
+    cases = [
+        "GP", # diagonalize, train scalar GP, assume diag inputs
+        "RF-vector-svd-nonsep",
+    ]
+
+    #### CHOOSE YOUR CASE: 
+    mask = [1] # 1:8 # e.g. 1:8 or [7]
+    for (case) in cases[mask]
+
+
+        println("case: ", case)
+        min_iter = 1
+        max_iter = 5 # number of EKP iterations to use data from is at most this
+        overrides = Dict(
+            "verbose" => true,
+            "scheduler" => DataMisfitController(terminate_at = 100.0),
+            "cov_sample_multiplier" => 0.5,
+            "n_iteration" => 20,
+            "n_ensemble" => 120,
+            "localization" => Localizers.SECNice(1000,0.1,1.0),
+        )
+        # we do not want termination, as our priors have relatively little interpretation
+
+        # Should be loaded:
+        dim = 2
+        N, L = 80, 1.0
+        pts_per_dim = LinRange(0, L, N)
+        obs_ΔN = 10
+        smoothness = 1.0
+        corr_length = 0.25
+        dofs = 20 # i.e. the input space dimension
+        ####
+
+        exp_name = "darcy"
+        rng_seed = 940284
+        rng = Random.MersenneTwister(rng_seed)
+
+        # loading relevant data
+        homedir = pwd()
+        println(homedir)
+        figure_save_directory = joinpath(homedir, "output/")
+        data_save_directory = joinpath(homedir, "output/")
+        data_save_file = joinpath(data_save_directory, "calibrate_results.jld2")
+
+        if !isfile(data_save_file)
+            throw(
+                ErrorException(
+                    "data file $data_save_file not found. \n First run: \n > julia --project calibrate.jl \n and store results $data_save_file",
+                ),
+            )
+        end
+
+        ekiobj = load(data_save_file)["eki"]
+        prior = load(data_save_file)["prior"]
+        truth_sample = load(data_save_file)["truth_sample"]
+        truth_params_constrained = load(data_save_file)["truth_input_constrained"] #true parameters in constrained space
+        truth_params = load(data_save_file)["truth_input_unconstrained"] #true parameters in unconstrained space  
+        Γy = get_obs_noise_cov(ekiobj)
+
+
+        n_params = length(truth_params) # "input dim"
+        output_dim = size(Γy, 1)
+        ###
+        ###  Emulate: Gaussian Process Regression
+        ###
+
+        # Emulate-sample settings
+        # choice of machine-learning tool in the emulation stage
+        nugget = 1e-12
+        if case == "GP"
+#            gppackage = Emulators.SKLJL()
+            gppackage = Emulators.GPJL()
+            mlt = GaussianProcess(
+                gppackage;
+                noise_learn = false,
+            )
+        elseif case ∈ ["RF-vector-svd-nonsep"]
+            kernel_structure = NonseparableKernel(LowRankFactor(1, nugget))
+            n_features = 100
+
+            mlt = VectorRandomFeatureInterface(
+                n_features,
+                n_params,
+                output_dim,
+                rng = rng,
+                kernel_structure = kernel_structure,
+                optimizer_options = overrides,
+            )
+        end
+
+
+        # Get training points from the EKP iteration number in the second input term  
+        N_iter = min(max_iter, length(get_u(ekiobj)) - 1) # number of paired iterations taken from EKP
+        min_iter = min(max_iter, max(1, min_iter))
+        input_output_pairs = Utilities.get_training_points(ekiobj, min_iter:(N_iter - 1))
+        input_output_pairs_test = Utilities.get_training_points(ekiobj, N_iter:(length(get_u(ekiobj)) - 1)) #  "next" iterations
+        # Save data
+        @save joinpath(data_save_directory, "input_output_pairs.jld2") input_output_pairs
+
+        retained_svd_frac = 1.0
+        normalized = true
+        # do we want to use SVD to decorrelate outputs
+        decorrelate = case ∈ ["RF-vector-nosvd-diag", "RF-vector-nosvd-nondiag"] ? false : true
+
+        emulator = Emulator(
+            mlt,
+            input_output_pairs;
+            obs_noise_cov = Γy,
+            normalize_inputs = normalized,
+            retained_svd_frac = retained_svd_frac,
+            decorrelate = decorrelate,
+        )
+        optimize_hyperparameters!(emulator)
+
+        # Check how well the Gaussian Process regression predicts on the
+        # true parameters
+        #if retained_svd_frac==1.0
+        y_mean, y_var = Emulators.predict(emulator, reshape(truth_params, :, 1), transform_to_real = true)
+        y_mean_test, y_var_test =
+            Emulators.predict(emulator, get_inputs(input_output_pairs_test), transform_to_real = true)
+
+        println("ML prediction on true parameters: ")
+        println(vec(y_mean))
+        println("true data: ")
+        println(truth_sample) # what was used as truth
+        println(" ML predicted standard deviation")
+        println(sqrt.(diag(y_var[1], 0)))
+        println("ML MSE (truth): ")
+        println(mean((truth_sample - vec(y_mean)) .^ 2))
+        println("ML MSE (next ensemble): ")
+        println(mean((get_outputs(input_output_pairs_test) - y_mean_test) .^ 2))
+
+        #end
+        ###
+        ###  Sample: Markov Chain Monte Carlo
+        ###
+        # initial values
+        u0 = vec(mean(get_inputs(input_output_pairs), dims = 2))
+        println("initial parameters: ", u0)
+
+        # First let's run a short chain to determine a good step size
+        mcmc = MCMCWrapper(RWMHSampling(), truth_sample, prior, emulator; init_params = u0)
+        new_step = optimize_stepsize(mcmc; init_stepsize = 0.1, N = 2000, discard_initial = 0)
+
+        # Now begin the actual MCMC
+        println("Begin MCMC - with step size ", new_step)
+        chain = MarkovChainMonteCarlo.sample(mcmc, 100_000; stepsize = new_step, discard_initial = 2_000)
+
+        posterior = MarkovChainMonteCarlo.get_posterior(mcmc, chain)
+
+        post_mean = mean(posterior)
+        post_cov = cov(posterior)
+        println("post_mean")
+        println(post_mean)
+        println("post_cov")
+        println(post_cov)
+        println("D util")
+        println(det(inv(post_cov)))
+        println(" ")
+
+        param_names = get_name(posterior)
+
+        posterior_samples = vcat([get_distribution(posterior)[name] for name in get_name(posterior)]...) #samples are columns
+        constrained_posterior_samples =
+            mapslices(x -> transform_unconstrained_to_constrained(posterior, x), posterior_samples, dims = 1)
+
+
+        # Save data
+        save(
+            joinpath(data_save_directory, "posterior.jld2"),
+            "posterior",
+            posterior,
+            "input_output_pairs",
+            input_output_pairs,
+            "truth_params",
+            truth_params,
+        )
+    end
+end
+
+main()

--- a/examples/Darcy/emulate_sample.jl
+++ b/examples/Darcy/emulate_sample.jl
@@ -22,7 +22,6 @@ function main()
 
     cases = [
         "GP", # diagonalize, train scalar GP, assume diag inputs
-        "RF-vector-svd-nonsep",
     ]
 
     #### CHOOSE YOUR CASE: 
@@ -33,25 +32,6 @@ function main()
         println("case: ", case)
         min_iter = 1
         max_iter = 5 # number of EKP iterations to use data from is at most this
-        overrides = Dict(
-            "verbose" => true,
-            "scheduler" => DataMisfitController(terminate_at = 100.0),
-            "cov_sample_multiplier" => 0.5,
-            "n_iteration" => 20,
-            "n_ensemble" => 120,
-            "localization" => Localizers.SECNice(1000, 0.1, 1.0),
-        )
-        # we do not want termination, as our priors have relatively little interpretation
-
-        # Should be loaded:
-        dim = 2
-        N, L = 80, 1.0
-        pts_per_dim = LinRange(0, L, N)
-        obs_ΔN = 10
-        smoothness = 1.0
-        corr_length = 0.25
-        dofs = 20 # i.e. the input space dimension
-        ####
 
         exp_name = "darcy"
         rng_seed = 940284
@@ -93,18 +73,6 @@ function main()
             #            gppackage = Emulators.SKLJL()
             gppackage = Emulators.GPJL()
             mlt = GaussianProcess(gppackage; noise_learn = false)
-        elseif case ∈ ["RF-vector-svd-nonsep"]
-            kernel_structure = NonseparableKernel(LowRankFactor(1, nugget))
-            n_features = 100
-
-            mlt = VectorRandomFeatureInterface(
-                n_features,
-                n_params,
-                output_dim,
-                rng = rng,
-                kernel_structure = kernel_structure,
-                optimizer_options = overrides,
-            )
         end
 
 

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -610,12 +610,12 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
     # live in same space as prior
     # checks if a function distribution, by looking at if the distribution is nested
     p_constraints = [
-        !isa(get_distribution(mcmc.prior)[pn],ParameterDistribution) ? # if not func-dist
+        !isa(get_distribution(mcmc.prior)[pn], ParameterDistribution) ? # if not func-dist
         flat_constraints[slice] : # constraints are slice
         get_all_constraints(get_distribution(mcmc.prior)[pn]) # get constraints of nested dist
         for (pn, slice) in zip(p_names, p_slices)
     ]
-    
+
     # distributions created as atoms and pieced together
     posterior_distribution = combine_distributions([
         ParameterDistribution(ps, pc, pn) for (ps, pc, pn) in zip(p_samples, p_constraints, p_names)

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -612,8 +612,8 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
     p_constraints = [
         !isa(get_distribution(mcmc.prior)[pn],ParameterDistribution) ? # if not func-dist
         flat_constraints[slice] : # constraints are slice
-        get_all_constraints(get_distribution(mcmc.prior)[ps]) # get constraints of nested dist
-        for (pn,slice) in zip(p_names, p_slices)
+        get_all_constraints(get_distribution(mcmc.prior)[pn]) # get constraints of nested dist
+        for (pn, slice) in zip(p_names, p_slices)
     ]
     
     # distributions created as atoms and pieced together

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -123,7 +123,7 @@ rng = Random.MersenneTwister(seed)
         # normal condition number should be huge around 10^18
         # nice cov will have improved conditioning, does not perform as well at this task as shrinking so has looser bounds
         good_cov = nice_cov(samples)
-        @test (cond(good_cov) < 100) && ((good_cov[1] < 1.5) && (good_cov[1] > 0.5))
+        @test (cond(good_cov) < 100) && ((good_cov[1] < 2.0) && (good_cov[1] > 0.2))
 
     end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- To introduce the Darcy flow example to help validate higher-dimensional methods for Emulation and sampling.
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
Closes #323
Closes #324 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Add the Darcy flow example from EnsembleKalmanProcesses.jl (See [here](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/examples/darcy/)), learning a permeability field from some discrete pressure observations
- Modify `src/MarkovChainMonteCarlo` `get_posterior(` to handle loading the function parameter
- reduced brittleness of a condition-number test on matrix
## Example output
from the calibration: 

prior
![output_prior](https://github.com/user-attachments/assets/4abc6fcd-45a5-42d9-9876-b0cb9854e81a)
final iteration 
![output_it_5](https://github.com/user-attachments/assets/ed8cdc5c-98b3-499c-803c-f7350fa64c76)
truth
![output_true](https://github.com/user-attachments/assets/10115f49-e409-4c5a-b25c-ee357fbee747)

note these are not seeded so the randomness likely will change the result each time.

from the emulate_sample.jl
Emulator check:
```
ML prediction on true parameters: 
[27.037408018242395, 38.87046139907847, 44.20165141698669, 44.81967460948412, 37.95762890768021, 27.084696766779054, 14.284342254286276, 41.225315659861174, 65.20877142866557, 75.4871734698289, 75.89983759897456, 65.89528866862894, 48.64379706569926, 26.77602042655126, 52.41126175374155, 83.2144993558748, 97.42776407311258, 98.3148676162914, 85.31481608662372, 63.293498366057726, 34.74875453547942, 61.561746712433695, 94.74782841985235, 112.44553354480084, 116.54156132625108, 99.5182177748717, 73.15942728881657, 39.47475688708078, 60.271179410024565, 97.02765814231405, 116.51247982894408, 121.15894751771309, 106.44717126532579, 80.16419988957492, 44.630376135296885, 54.25445794702326, 89.28033820768455, 107.54747440965036, 111.84523353382397, 101.5759088113121, 79.98653047792462, 47.54441991685336, 38.62524359313755, 61.82144722190585, 74.33157261921035, 78.27094847216169, 72.00563201011728, 58.548161131379715, 37.136865856168434]
true data: 
[23.84984138170094, 34.07464189113868, 45.416933138479166, 44.07931284195099, 33.65233298120436, 33.01615021178614, 15.077839776390611, 46.858281713105896, 67.01867480773103, 78.536759250763, 80.4860269350031, 66.12220208826437, 48.72938148448155, 26.687674306444382, 52.68364578726671, 87.6429536245335, 101.59518527623275, 98.06482852584509, 84.48714624938796, 61.315687335509736, 33.372651588657256, 53.66877549346963, 88.99212547729059, 112.40516507316904, 114.08675602624477, 95.55222700277633, 73.39447680369074, 43.254623784078646, 64.2228045937796, 95.41500420534308, 112.70626702034014, 117.75064097762899, 103.06978425812935, 77.76447284695995, 44.869216531401364, 54.90382329022393, 89.94842682627534, 105.36102533892421, 113.34730085341785, 105.18675551571583, 82.26396614996443, 46.369884629910466, 34.33466615937397, 63.802573464988754, 75.41489892667848, 77.25768123625558, 71.50004108831035, 62.207867252294854, 41.076630593780834]
 ML predicted standard deviation
[2.609234092147626, 2.6059894762299933, 2.607473226550132, 2.612071197290017, 2.613743191102169, 2.614594101414251, 2.6135702847721385, 2.600191409539615, 2.600558328408845, 2.6002529606771305, 2.599717195096206, 2.6137828393644242, 2.615427558326809, 2.614288407835236, 2.6135301648397196, 2.61622373875433, 2.616501522987768, 2.6153526510313894, 2.599263431097443, 2.6142356710712096, 2.6150421836682884, 2.6190301454640474, 2.6174928501072725, 2.6184783694424563, 2.619186848031698, 2.615045216646557, 2.6120309645626043, 2.6152856355464835, 2.6153003997900885, 2.6171139124799914, 2.6192066232734224, 2.6192030742448265, 2.6157746075086825, 2.6012162999103468, 2.614387290585893, 2.6007390677078344, 2.6153682904050264, 2.6176116959855107, 2.6176292392538443, 2.615466725101344, 2.6101420829569135, 2.615154402007166, 2.615674479178309, 2.60132642271825, 2.6152681106034272, 2.616475362834447, 2.611383358599127, 2.6146592701107996, 2.61786014770975]
ML MSE (truth): 
9.649540741225902
ML MSE (next ensemble): 
0.013397421420773633
```
and the UQ check :
```
post_mean
[0.983561876339554; -0.9581797789308962; 0.9485901106700727; 1.2076572098239085; -0.5724392937657472;;]
post_cov
[0.001240363115299256 0.0007521635791415857 0.0009539072667421793 7.79372640360373e-5 8.636512376624956e-5; 0.0007521635791415857 0.005702149781800616 -0.00041195632220727507 -0.004067959894947535 -0.0005367145219895543; 0.0009539072667421793 -0.00041195632220727507 0.004952320816263619 0.0010380776193430995 -0.0008631261725693903; 7.79372640360373e-5 -0.004067959894947535 0.0010380776193430995 0.029750884482751237 5.5897073597492775e-5; 8.636512376624956e-5 -0.0005367145219895543 -0.0008631261725693903 5.5897073597492775e-5 0.02958700649705789]
D util
4.917659459703968e10
```
pointwise uq - (mean should be similar to calibrate result, but uncertainty is usually a larger magnitude variance in colourbar). Pushed forward mean permeability to get pressure here for now
![GP_posterior_pointwise_uq](https://github.com/user-attachments/assets/6b7b055f-8ed4-4e8c-9c7f-ebad95d648d1)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
