### PR TITLE
Fix python dependency issues with Python 3.12 and add to docs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,6 @@ steps:
       - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project -e 'using Conda; Conda.add(\"scipy=1.14.1\", channel=\"conda-forge\")'"
       - "julia --project -e 'using Conda; Conda.add(\"scikit-learn=1.5.1\")'"
-      - "julia --project -e 'using Conda; Conda.add(\"matplotlib=3.7.1\")'"
     env:
       PYTHON: ""
       

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,8 +12,8 @@ steps:
     command:
       - "echo $$JULIA_DEPOT_PATH"
       - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project -e 'using Conda; Conda.add(\"scipy=1.8.1\", channel=\"conda-forge\")'"
-      - "julia --project -e 'using Conda; Conda.add(\"scikit-learn=1.1.1\")'"
+      - "julia --project -e 'using Conda; Conda.add(\"scipy=1.14.1\", channel=\"conda-forge\")'"
+      - "julia --project -e 'using Conda; Conda.add(\"scikit-learn=1.5.1\")'"
       - "julia --project -e 'using Conda; Conda.add(\"matplotlib=3.7.1\")'"
     env:
       PYTHON: ""

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -36,8 +36,8 @@ jobs:
           PYTHON: ""
         run: |
           julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'
-          julia --project -e 'using Conda; Conda.add("scipy=1.8.1")'
-          julia --color=yes --project -e 'using Conda; Conda.add("scikit-learn=1.1.1")'
+          julia --project -e 'using Conda; Conda.add("scipy=1.14.1")'
+          julia --color=yes --project -e 'using Conda; Conda.add("scikit-learn=1.5.1")'
           julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'
           julia --color=yes --project=docs/ -e 'using Pkg; Pkg.precompile()'
       - name: Build and deploy

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -39,8 +39,8 @@ jobs:
       env:
         PYTHON: ""
       run: |
-        julia --project -e 'using Conda; Conda.add("scipy=1.8.1")'
-        julia --project -e 'using Conda; Conda.add("scikit-learn=1.1.1")'
+        julia --project -e 'using Conda; Conda.add("scipy=1.14.1")'
+        julia --project -e 'using Conda; Conda.add("scikit-learn=1.5.1")'
 
     - name: Run Unit Tests
       env:
@@ -92,8 +92,8 @@ jobs:
       env:
         PYTHON: ""
       run: |
-        julia --project -e 'using Conda; Conda.add("scipy=1.8.1")'
-        julia --project -e 'using Conda; Conda.add("scikit-learn=1.1.1")'
+        julia --project -e 'using Conda; Conda.add("scipy=1.14.1")'
+        julia --project -e 'using Conda; Conda.add("scikit-learn=1.5.1")'
 
     - name: Run Unit Tests
       env:
@@ -132,8 +132,8 @@ jobs:
       env:
         PYTHON: ""
       run: |
-        julia --project -e 'using Conda; Conda.add("scipy=1.8.1")'
-        julia --project -e 'using Conda; Conda.add(\"scikit-learn=1.1.1\")'
+        julia --project -e 'using Conda; Conda.add("scipy=1.14.1")'
+        julia --project -e 'using Conda; Conda.add(\"scikit-learn=1.5.1\")'
 
     - name: Run Unit Tests
       env:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -133,7 +133,7 @@ jobs:
         PYTHON: ""
       run: |
         julia --project -e 'using Conda; Conda.add("scipy=1.14.1")'
-        julia --project -e 'using Conda; Conda.add(\"scikit-learn=1.5.1\")'
+        julia --project -e 'using Conda; Conda.add("scikit-learn=1.5.1")'
 
     - name: Run Unit Tests
       env:

--- a/docs/src/installation_instructions.md
+++ b/docs/src/installation_instructions.md
@@ -3,8 +3,12 @@
 ### Installing CalibrateEmulateSample.jl
 
 Currently CalibrateEmulateSample (CES) depends on some external python dependencies 
-including `scipy` (version `1.8.1` works) and `scikit-learn` (version `1.1.1` works) that are wrapped by ScikitLearn.jl.
-
+!!! info "Latest python package versions!"
+    We have verified that the configurations work:
+    For Python `3.11 - 3.12`: `scipy` = `1.14.1`, `scikit-learn` = `1.5.1`.
+    For Python `3.8 - 3.11`: `scipy` = `1.8.1`, `scikit-learn` = `1.1.1`.
+    Please create an issue if you have had success with more up-to-date versions, and we can update this page!
+    
 If you have dependencies installed already, then the code can be used by simply entering
 
 ```
@@ -32,10 +36,24 @@ Then install the dependencies by having the project use its own [Conda](https://
 This call should build Conda and Pycall. The `scikit-learn` package (along with `scipy`) then has to be installed if using a Julia project-specific Conda environment:
 
 ```
-> PYTHON="" julia --project -e 'using Conda; Conda.add("scipy=1.8.1", channel="conda-forge")'
-> PYTHON="" julia --project -e 'using Conda; Conda.add("scikit-learn=1.1.1")'
+> PYTHON="" julia --project -e 'using Conda; Conda.add("scipy=1.14.1", channel="conda-forge")'
+> PYTHON="" julia --project -e 'using Conda; Conda.add("scikit-learn=1.5.1")'
 
 ```
+!!! info "Pycall can't find the packages!?"
+    Sometimes `Conda.jl` builds the python packages, in julia-based python repo but Pycall resorts to a different python path. this throws an error like:
+    ```
+        ERROR: InitError: PyError (PyImport_ImportModule
+
+    The Python package sklearn.gaussian_process.kernels could not be imported by pyimport.
+    ```
+    In this case, simply call `julia --project` followed by
+    ```julia
+    julia> ENV["PYTHON"]=""
+    julia> Pkg.build("PyCall")
+    julia> exit()
+    ```
+    to reset unify the paths.
 
 See the [PyCall.jl documentation](https://github.com/JuliaPy/PyCall.jl#specifying-the-python-version) 
 for more information about how to configure the local Julia / Conda / Python environment. 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

Closes #317

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- update buildkite and testing to Python 3.12-compatible scipy  (v1.14.1) and scikitlearn (v1.5.1)
- removed matplotlib (we do not need this?)
- add this update and other installation help in docs page
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
