### PR TITLE
WIP: Enable (naive) minibatching within MCMC.

### DIFF
--- a/docs/src/API/MarkovChainMonteCarlo.md
+++ b/docs/src/API/MarkovChainMonteCarlo.md
@@ -8,7 +8,14 @@ CurrentModule = CalibrateEmulateSample.MarkovChainMonteCarlo
 
 ```@docs
 MCMCWrapper
-MCMCWrapper(args...; kwargs...)
+MCMCWrapper(
+    mcmc_alg::MCMCProtocol,
+    observation::AMorAV,
+    prior::ParameterDistribution,
+    em::Emulator;
+    kwargs...,
+) where {AV <: AbstractVector, AMorAV <: Union{AbstractVector, AbstractMatrix}}
+
 sample
 get_posterior
 optimize_stepsize

--- a/docs/src/API/MarkovChainMonteCarlo.md
+++ b/docs/src/API/MarkovChainMonteCarlo.md
@@ -8,7 +8,7 @@ CurrentModule = CalibrateEmulateSample.MarkovChainMonteCarlo
 
 ```@docs
 MCMCWrapper
-MCMCWrapper(mcmc_alg::MCMCProtocol, obs_sample::AbstractVector{FT}, prior::ParameterDistribution, em::Emulator;init_params::AbstractVector{FT}, burnin::IT, kwargs...) where {FT<:AbstractFloat, IT<:Integer}
+MCMCWrapper(args...; kwargs...)
 sample
 get_posterior
 optimize_stepsize

--- a/docs/src/sample.md
+++ b/docs/src/sample.md
@@ -30,6 +30,9 @@ mcmc = MCMCWrapper(
 ```
 The keyword arguments `init_params` give a starting step of the chain (often taken to be the mean of the final iteration of calibrate stage), and a `burnin` gives a number of initial steps to be discarded when drawing statistics from the sampling method.
 
+!!! note "for many samples"
+    If one has several samples of conditionally-independent data (that is, ``p({y_1,\dots,y_n}\mid\theta)`` is a product of ``\prod_i p(y_i\mid\theta)``), then one can feed in `truth_sample` as a vector of these samples ``y_ii`` or as a matrix. The resulting sampler will evaluate the likelihood at all y_i for every sample step. 
+
 For good efficiency, one often needs to run MCMC with a problem-dependent step size. We provide a simple utility to help choose this. Here the optimizer runs short chains (of length `N`), and adjusts the step-size until the MCMC acceptance rate falls within an acceptable range, returning this step size.
 ```julia
 new_step = optimize_stepsize(

--- a/docs/src/sample.md
+++ b/docs/src/sample.md
@@ -31,7 +31,7 @@ mcmc = MCMCWrapper(
 The keyword arguments `init_params` give a starting step of the chain (often taken to be the mean of the final iteration of calibrate stage), and a `burnin` gives a number of initial steps to be discarded when drawing statistics from the sampling method.
 
 !!! note "for many samples"
-    If one has several samples of conditionally-independent data (that is, ``p({y_1,\dots,y_n}\mid\theta)`` is a product of ``\prod_i p(y_i\mid\theta)``), then one can feed in `truth_sample` as a vector of these samples ``y_ii`` or as a matrix. The resulting sampler will evaluate the likelihood at all y_i for every sample step. 
+    If one has several samples of conditionally-independent data (that is, ``p({y_1,\dots,y_n}\mid\theta)`` is a product of ``\prod_i p(y_i\mid\theta)``), then one can feed in `truth_sample` as a vector of these samples, or a matrix with these samples as columns. The resulting sampler will evaluate the likelihood at all `y_i` for every sample step. 
 
 For good efficiency, one often needs to run MCMC with a problem-dependent step size. We provide a simple utility to help choose this. Here the optimizer runs short chains (of length `N`), and adjusts the step-size until the MCMC acceptance rate falls within an acceptable range, returning this step size.
 ```julia

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -68,7 +68,7 @@ end
 
 function to_decorrelated(data::AbstractMatrix{FT}, em::Emulator{FT}) where {FT <: AbstractFloat}
     # method for Matrix with columns that are samples
-    return [vec(to_decorrelated(cd, em), single_vec = false) for cd in eachcolumn(data)]
+    return [vec(to_decorrelated(cd, em, single_vec = false)) for cd in eachcol(data)]
 
 end
 

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -74,7 +74,7 @@ function to_decorrelated(data::AVV, em::Emulator{FT}) where {AVV <: AbstractVect
     if isa(data[1], AbstractVector)
         return [vec(to_decorrelated(reshape(d, :, 1), em)) for d in data] # calls matrix version
     else # 
-        return to_decorrelated(convert.(FT, data))
+        return to_decorrelated(convert.(FT, data), em)
     end
 end
 

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -259,8 +259,8 @@ end
         @test isapprox(new_step, 0.5; atol = 0.5)
         # difference between mean_1 and ground truth comes from MCMC convergence and GP sampling
         @test isapprox(posterior_mean_1, π / 2; atol = 4e-1)
-        
-        
+
+
     end
 
     @testset "Sine GP & pCN" begin

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -260,7 +260,7 @@ end
         # difference between mean_1 and ground truth comes from MCMC convergence and GP sampling
         @test isapprox(posterior_mean_1, π / 2; atol = 4e-1)
 
-        
+
         # test with int data
         obs_sample3 = [1]
         mcmc_params3 = mcmc_params

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -225,7 +225,7 @@ end
         @test isapprox(posterior_mean_1b, posterior_mean_1; atol = tol_small)
         esjd1b = esjd(chain_1b)
         @info "ESJD = $esjd1b"
-        @test all(isapprox.(esjd1, esjd1b, rtol = 0.1))
+        @test all(isapprox.(esjd1, esjd1b, rtol = 0.2))
 
         # now test SVD normalization
         norm_factor = 10.0
@@ -238,7 +238,7 @@ end
         esjd2 = esjd(chain_2)
         @info "ESJD = $esjd2"
         # approx [0.04190683285347798, 0.1685296224916364, 0.4129400000002722]
-        @test all(isapprox.(esjd1, esjd2, rtol = 0.1))
+        @test all(isapprox.(esjd1, esjd2, rtol = 0.2))
 
         # test with many slightly different samples
         obs_sample2 = [obs_sample + 0.01 * randn(length(obs_sample)) for i in 1:100]
@@ -287,7 +287,7 @@ end
         @test isapprox(posterior_mean_1b, posterior_mean_1; atol = tol_small)
         esjd1b = esjd(chain_1b)
         @info "ESJD = $esjd1b"
-        @test all(isapprox.(esjd1, esjd1b, rtol = 0.1))
+        @test all(isapprox.(esjd1, esjd1b, rtol = 0.2))
 
         # now test SVD normalization
         norm_factor = 10.0
@@ -301,7 +301,7 @@ end
         @info "ESJD = $esjd2"
         # approx [0.03470825350663073, 0.161606734823579, 0.38970000000024896]
 
-        @test all(isapprox.(esjd1, esjd2, rtol = 0.1))
+        @test all(isapprox.(esjd1, esjd2, rtol = 0.2))
 
     end
 

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -163,8 +163,8 @@ function mcmc_test_template(
     rng = Random.GLOBAL_RNG,
     target_acc = 0.25,
 )
-    if !isa(obs_sample, AbstractVector)
-        obs_sample = reshape(collect(obs_sample), 1) # scalar or Vector -> Vector
+    if !isa(obs_sample, AbstractVecOrMat)
+        obs_sample = reshape(collect(obs_sample), 1) # scalar -> Vector 
     end
 
     init_params = reshape(collect(init_params), 1) # scalar or Vector -> Vector

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -241,6 +241,7 @@ end
         @test all(isapprox.(esjd1, esjd2, rtol = 0.2))
 
         # test with many slightly different samples
+        # as vec of vec
         obs_sample2 = [obs_sample + 0.01 * randn(length(obs_sample)) for i in 1:100]
         mcmc_params2 = mcmc_params
         mcmc_params2[:obs_sample] = obs_sample2
@@ -250,6 +251,16 @@ end
         # difference between mean_1 and ground truth comes from MCMC convergence and GP sampling
         @test isapprox(posterior_mean_1, π / 2; atol = 4e-1)
 
+        # as column matrix
+        obs_sample2mat = reduce(hcat, obs_sample2)
+        mcmc_params2mat = mcmc_params
+        mcmc_params2mat[:obs_sample] = obs_sample2mat
+        new_step, posterior_mean_1 = mcmc_test_template(prior, σ2_y, em_1; mcmc_params2mat...)
+        @test isapprox(new_step, 0.5; atol = 0.5)
+        # difference between mean_1 and ground truth comes from MCMC convergence and GP sampling
+        @test isapprox(posterior_mean_1, π / 2; atol = 4e-1)
+
+        
         # test with int data
         obs_sample3 = [1]
         mcmc_params3 = mcmc_params

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -250,6 +250,17 @@ end
         # difference between mean_1 and ground truth comes from MCMC convergence and GP sampling
         @test isapprox(posterior_mean_1, π / 2; atol = 4e-1)
 
+        # test with int data
+        obs_sample3 = [1]
+        mcmc_params3 = mcmc_params
+        mcmc_params3[:obs_sample] = obs_sample3
+        em_1 = test_gp_1(y, σ2_y, iopairs)
+        new_step, posterior_mean_1 = mcmc_test_template(prior, σ2_y, em_1; mcmc_params3...)
+        @test isapprox(new_step, 0.5; atol = 0.5)
+        # difference between mean_1 and ground truth comes from MCMC convergence and GP sampling
+        @test isapprox(posterior_mean_1, π / 2; atol = 4e-1)
+        
+        
     end
 
     @testset "Sine GP & pCN" begin


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- New method to decorrelate a vector of data sample vectors
- New emulator posterior function that still enables us to build the (cumbersome) AdvancedMH.DensityModel object. using by defining `x -> f(x, emulator, prior, data)` in the factory
- emulator posterior now taks 1/n * sum(log(p(y_i|x))) + log_prior(x)` over the data vector `y_i in Y`. This is a naive formulation, requiring `n` evaluations of the emulator for every MCMC step.
- added a unit test where 100 slightly perturbed data samples, and acheive the same target.

## Misc
The net result of [(Barbenet, Doucet, Holmes 2017)](https://jmlr.org/papers/v18/15-205.html) )  is that minibatching within MCMC is a very technically complex problem, and for computational benefit without loss of accuracy requires a nested procedure to approximate the accept-reject mechanicsm, and futher surrogates of the log-likelihood. It may be that simple parallelization or alternative (parallel) sampling methods would be preferred
- The `ObservationSeries` object contains both data samples and noise covariance. Here it appears that MCMC requires only the data samples, while the emulator uses the noise covariance (for decorrelation), this should be addressed in a future issue to do with data processing but not here


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
