### PR TITLE
CES with spatially dependent forcing of L96

### DIFF
--- a/examples/Lorenz/Project.toml
+++ b/examples/Lorenz/Project.toml
@@ -1,4 +1,3 @@
-
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 AdvancedMH = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"

--- a/examples/Lorenz/Project.toml
+++ b/examples/Lorenz/Project.toml
@@ -1,3 +1,4 @@
+
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 AdvancedMH = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -296,6 +296,7 @@ if ~isdir(data_save_directory)
 end
 
 # Create plots
+using Plots.Measures
 gr(size=(2*1.6*300,300))
 p1 = plot(
     range(0, nx - 1, step = 1),
@@ -305,6 +306,8 @@ p1 = plot(
     linewidth = 2,
     xlabel = "Spatial index",
     ylabel = "Forcing (input)",
+    left_margin = 10mm,
+    bottom_margin = 10mm,
 )
 
 p2 = plot(
@@ -316,6 +319,8 @@ p2 = plot(
     linewidth = 2,
     xlabel = "Spatial index",
     ylabel = "Lorenz state (output)",
+    left_margin = 10mm,
+    bottom_margin = 10mm,
 )
 l = @layout [a b]
 plt = plot(p1,p2, layout = l)

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -294,17 +294,17 @@ savefig(hm, joinpath(figure_save_directory, "spun_up_heatmap.png"))
 savefig(hm, joinpath(figure_save_directory, "spun_up_heatmap.pdf"))
 
 using Plots.Measures
-gr(size = (2 * 1.6 * 300, 300))
+gr(size = (2 * 1.6 * 600, 600), guidefontsize = 18, tickfontsize = 16, legendfontsize = 16)
 p1 = plot(
-    range(0, nx - 1, step = 1),
+    range(0, nx-1, step = 1),
     [gamma mean(final_ensemble, dims = 2)],
     label = ["solution" "EKI"],
     color = [:black :lightgreen],
-    linewidth = 2,
+    linewidth = 4,
     xlabel = "Spatial index",
     ylabel = "Forcing (input)",
-    left_margin = 10mm,
-    bottom_margin = 10mm,
+    left_margin = 15mm,
+    bottom_margin = 15mm,
 )
 
 p2 = plot(
@@ -313,11 +313,12 @@ p2 = plot(
     ribbon = sqrt.(diag(get_obs_noise_cov(ekpobj))),
     label = ["data" "mean-final-output"],
     color = [:black :lightgreen],
-    linewidth = 2,
+    linewidth = 4,
     xlabel = "Spatial index",
-    ylabel = "Lorenz state (output)",
-    left_margin = 10mm,
-    bottom_margin = 10mm,
+    ylabel = "State mean/std output)",
+    left_margin = 15mm,
+    bottom_margin = 15mm,
+    xticks= (Int.(0:10:ny), [0,10,20,30,(40,0),10,20,30,40])
 )
 l = @layout [a b]
 plt = plot(p1, p2, layout = l)

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -170,7 +170,7 @@ x0 = x_spun_up[:, end]  #last element of the run is the initial condition for cr
 
 
 #Creating my sythetic data
-T = 104.0
+T = 14.0
 ny = nx * 2   #number of data points
 lorenz_config_settings = LorenzConfig(t, T)
 
@@ -181,18 +181,12 @@ observation_config = ObservationConfig(T_start, T_end)
 
 model_out_y = lorenz_forward(true_parameters, x0, lorenz_config_settings, observation_config)
 
-#Observation covariance R (Not including internal variability...)
-model_out_vars = (0.1 * model_out_y) .^ 2
-R = Diagonal(model_out_vars)
-R_sqrt = sqrt(R)
-R_inv_var = sqrt(inv(R))
-
-# Need a way to perturb the initial condition when doing the EKI updates
-# Solving for initial condition perturbation covariance
-covT = 2000.0  #time to simulate to calculate a covariance matrix of the system
+#Observation covariance
+# [Don't need to do this bit really] - initial condition perturbations
+covT = 1000.0  #time to simulate to calculate a covariance matrix of the system
 cov_solve = lorenz_solve(true_parameters, x0, LorenzConfig(t, covT))
 ic_cov = 0.1 * cov(cov_solve, dims = 2)
-ic_cov_sqrt = sqrt(ic_cov)
+ic_cov_sqrt = sqrt(ic_cov) 
 
 n_samples = 200
 y_ens = hcat(
@@ -207,7 +201,7 @@ y_ens = hcat(
 )
 
 # estimate noise from IC-effect + R
-obs_noise_cov = R + cov(y_ens, dims=2)
+obs_noise_cov = cov(y_ens, dims=2)
 y = y_ens[1]
 
 #Observations y

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -167,6 +167,8 @@ x_spun_up = lorenz_solve(true_parameters, x_initial, picking_initial_condition) 
 x0 = x_spun_up[:, end]  #last element of the run is the initial condition for creating the data
 
 
+
+
 #Creating my sythetic data
 T = 104.0
 ny = nx * 2   #number of data points
@@ -298,6 +300,12 @@ if ~isdir(data_save_directory)
 end
 
 # Create plots
+
+gr(size=(1.6*400,400))
+hm = heatmap(x_spun_up[:,end-10000:end], c = :viridis)
+savefig(hm, joinpath(figure_save_directory, "spun_up_heatmap.png"))
+savefig(hm, joinpath(figure_save_directory,"spun_up_heatmap.pdf"))
+
 using Plots.Measures
 gr(size=(2*1.6*300,300))
 p1 = plot(

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -296,20 +296,31 @@ if ~isdir(data_save_directory)
 end
 
 # Create plots
+gr(size=(2*1.6*300,300))
 p1 = plot(
     range(0, nx - 1, step = 1),
     [gamma mean(final_ensemble,dims=2)],
-    ribbon = 2*sqrt.(diag(obs_noise_cov)),
     label = ["solution" "EKI"],
     color = [:black :lightgreen],
     linewidth = 2,
     xlabel = "Spatial index",
-    ylabel = "Gamma",
-    title = "Optimized parameters for ensemble size = 50",
-    show = true,
+    ylabel = "Forcing (input)",
 )
-show(p1)
-savefig(p1, figure_save_directory * "solution_spatial_dep_ens$(N_ens).png")
+
+p2 = plot(
+    1:length(y),
+    [y get_g_mean_final(ekpobj)],
+    ribbon = sqrt.(diag(get_obs_noise_cov(ekpobj))),
+    label = ["data" "mean-final-output"],
+    color = [:black :lightgreen],
+    linewidth = 2,
+    xlabel = "Spatial index",
+    ylabel = "Lorenz state (output)",
+)
+l = @layout [a b]
+plt = plot(p1,p2, layout = l)
+
+savefig(plt, figure_save_directory * "solution_spatial_dep_ens$(N_ens).png")
 
 # save objects
 save(

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -309,10 +309,10 @@ p1 = plot(
 
 p2 = plot(
     1:length(y),
-    [y get_g_mean_final(ekpobj)],
+    y,
     ribbon = sqrt.(diag(get_obs_noise_cov(ekpobj))),
-    label = ["data" "mean-final-output"],
-    color = [:black :lightgreen],
+    label = "data",
+    color = :black,
     linewidth = 4,
     xlabel = "Spatial index",
     ylabel = "State mean/std output)",
@@ -320,6 +320,14 @@ p2 = plot(
     bottom_margin = 15mm,
     xticks= (Int.(0:10:ny), [0,10,20,30,(40,0),10,20,30,40])
 )
+plot!(p2,
+      1:length(y),
+      get_g_mean_final(ekpobj),
+      label = "mean-final-output",
+      color = :lightgreen,
+      linewidth = 4,
+)
+
 l = @layout [a b]
 plt = plot(p1, p2, layout = l)
 

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -1,0 +1,342 @@
+include("GModel.jl") # Contains Lorenz 96 source code
+
+# Import modules
+using Distributions  # probability distributions and associated functions
+using LinearAlgebra
+using StatsPlots
+using Plots
+using Random
+using JLD2
+using Statistics
+
+# CES 
+using CalibrateEmulateSample.EnsembleKalmanProcesses
+using CalibrateEmulateSample.EnsembleKalmanProcesses.ParameterDistributions
+using CalibrateEmulateSample.EnsembleKalmanProcesses.Localizers
+
+const EKP = EnsembleKalmanProcesses
+
+# G(θ) = H(Ψ(θ,x₀,t₀,t₁))
+# y = G(θ) + η
+
+# This will change for different Lorenz simulators
+struct LorenzConfig{FT1 <: Real, FT2 <: Real}
+    "Length of a fixed integration timestep"
+    dt::FT1
+    "Total duration of integration (T = N*dt)"
+    T::FT2
+end
+
+# This will change for each ensemble member
+struct EnsembleMemberConfig{VV <: AbstractVector}
+    "state-dependent-forcing"
+    F::VV
+end
+
+# This will change for different "Observations" of Lorenz
+struct ObservationConfig{FT1 <: Real, FT2 <: Real}
+    "initial time to gather statistics (T_start = N_start*dt)"
+    T_start::FT1
+    "end time to gather statistics (T_end = N_end*dt)"
+    T_end::FT2
+end
+#########################################################################
+############################ Model Functions ############################
+#########################################################################
+
+# Forward pass of forward model
+# Inputs: 
+# - params: structure with F (state-dependent-forcing vector)
+# - x0: initial condition vector
+# - config: structure including dt (timestep Float64(1)) and T (total time Float64(1))
+function lorenz_forward(
+    params::EnsembleMemberConfig,
+    x0::VorM,
+    config::LorenzConfig,
+    observation_config::ObservationConfig,
+) where {VorM <: AbstractVecOrMat}
+    # run the Lorenz simulation
+    xn = lorenz_solve(params, x0, config)
+    # Get statistics
+    gt = stats(xn, config, observation_config)
+    return gt
+end
+
+#Calculates statistics for forward model output
+# Inputs: 
+# - xn: timeseries of states for length of simulation through Lorenz96
+function stats(xn::VorM, config::LorenzConfig, observation_config::ObservationConfig) where {VorM <: AbstractVecOrMat}
+    T_start = observation_config.T_start
+    T_end = observation_config.T_end
+    dt = config.dt
+    N_start = Int(ceil(T_start / dt))
+    N_end = Int(ceil(T_end / dt))
+    xn_stat = xn[:, N_start:N_end]
+    N_state = size(xn_stat, 1)
+    gt = zeros(2 * N_state)
+    gt[1:N_state] = mean(xn_stat, dims = 2)
+    gt[(N_state + 1):(2 * N_state)] = std(xn_stat, dims = 2)
+    return gt
+end
+
+# Forward pass of the Lorenz 96 model
+# Inputs: 
+# - params: structure with F (state-dependent-forcing vector)
+# - x0: initial condition vector
+# - config: structure including dt (timestep Float64(1)) and T (total time Float64(1))
+function lorenz_solve(params::EnsembleMemberConfig, x0::VorM, config::LorenzConfig) where {VorM <: AbstractVecOrMat}
+    # Initialize    
+    nstep = Int(ceil(config.T / config.dt))
+    state_dim = isa(x0, AbstractVector) ? length(x0) : size(x0, 1)
+    xn = zeros(size(x0, 1), nstep + 1)
+    xn[:, 1] = x0
+
+    # March forward in time
+    for j in 1:nstep
+        xn[:, j + 1] = RK4(params, xn[:, j], config)
+    end
+    # Output
+    return xn
+end
+
+# Lorenz 96 system
+# f = dx/dt
+# Inputs: 
+# - params: structure with F (state-dependent-forcing vector) 
+# - x: current state
+function f(params::EnsembleMemberConfig, x::VorM) where {VorM <: AbstractVecOrMat}
+    F = params.F
+    N = length(x)
+    f = zeros(N)
+    # Loop over N positions
+    for i in 3:(N - 1)
+        f[i] = -x[i - 2] * x[i - 1] + x[i - 1] * x[i + 1] - x[i] + F[i]
+    end
+    # Periodic boundary conditions
+    f[1] = -x[N - 1] * x[N] + x[N] * x[2] - x[1] + F[1]
+    f[2] = -x[N] * x[1] + x[1] * x[3] - x[2] + F[2]
+    f[N] = -x[N - 2] * x[N - 1] + x[N - 1] * x[1] - x[N] + F[N]
+    # Output
+    return f
+end
+
+# RK4 solve
+# Inputs: 
+# - params: structure with F (state-dependent-forcing vector) 
+# - xold: current state
+# - config: structure including dt (timestep Float64(1)) and T (total time Float64(1))
+function RK4(params::EnsembleMemberConfig, xold::VorM, config::LorenzConfig) where {VorM <: AbstractVecOrMat}
+    N = length(xold)
+    dt = config.dt
+
+    # Predictor steps (note no time-dependence is needed here)
+    k1 = f(params, xold)
+    k2 = f(params, xold + k1 * dt / 2.0)
+    k3 = f(params, xold + k2 * dt / 2.0)
+    k4 = f(params, xold + k3 * dt)
+    # Step
+    xnew = xold + (dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4)
+    # Output
+    return xnew
+end
+
+
+########################################################################
+############################ Problem setup #############################
+########################################################################
+rng_seed_init = 11
+rng_i = MersenneTwister(rng_seed_init)
+
+#Creating my sythetic data
+#initalize model variables
+nx = 40  #dimensions of parameter vector
+gamma = 8 .+ 6 * sin.((4 * pi * range(0, stop = nx - 1, step = 1)) / nx)  #forcing (Needs to be of type EnsembleMemberConfig)
+true_parameters = EnsembleMemberConfig(gamma)
+
+t = 0.01  #time step
+T_long = 1000.0  #total time 
+picking_initial_condition = LorenzConfig(t, T_long)
+
+#beginning state
+x_initial = rand(rng_i, Normal(0.0, 1.0), nx)
+
+#Find the initial condition for my data
+x_spun_up = lorenz_solve(true_parameters, x_initial, picking_initial_condition)  #Need to make LorenzConfig object with t, T_long
+
+#intital condition used for the data
+x0 = x_spun_up[:, end]  #last element of the run is the initial condition for creating the data
+#Creating my sythetic data
+T = 104.0
+ny = nx * 2   #number of data points
+lorenz_config_settings = LorenzConfig(t, T)
+
+# construct how we compute Observations
+T_start = 4.0  #2*max
+T_end = T
+observation_config = ObservationConfig(T_start, T_end)
+
+model_out_y = lorenz_forward(true_parameters, x0, lorenz_config_settings, observation_config)
+
+#Observation covariance R (Not including internal variability...)
+model_out_vars = (0.1 * model_out_y) .^ 2
+R = Diagonal(model_out_vars)
+R_sqrt = sqrt(R)
+R_inv_var = sqrt(inv(R))
+
+# Need a way to perturb the initial condition when doing the EKI updates
+# Solving for initial condition perturbation covariance
+covT = 2000.0  #time to simulate to calculate a covariance matrix of the system
+cov_solve = lorenz_solve(true_parameters, x0, LorenzConfig(t, covT))
+ic_cov = 0.1 * cov(cov_solve, dims = 2)
+ic_cov_sqrt = sqrt(ic_cov)
+
+n_samples = 200
+y_ens = hcat(
+    [
+        lorenz_forward(
+            true_parameters,
+            (x0 .+ ic_cov_sqrt * rand(rng, Normal(0.0, 1.0), nx, n_samples))[:, j],
+            lorenz_config_settings,
+            observation_config,
+        ) for j in 1:N_ens
+            ]...,
+)
+
+# estimate noise from IC-effect + R
+obs_noise_cov = R + cov(y_ens, dims=2)
+y = y_ens[1]
+
+#Observations y
+y = model_out_y + R_sqrt * rand(rng_i, Normal(0.0, 1.0), ny)
+
+pl = 2.0
+psig = 3.0
+#Prior covariance
+B = zeros(nx, nx)
+for ii in 1:nx
+    for jj in 1:nx
+        B[ii, jj] = psig^2 * exp(-abs(ii - jj) / pl)
+    end
+end
+B_sqrt = sqrt(B)
+
+#Prior mean
+mu = 8.0 * ones(nx)
+
+#Creating prior distribution
+distribution = Parameterized(MvNormal(mu, B))
+constraint = repeat([no_constraint()], 40)
+name = "ml96_prior"
+
+prior = ParameterDistribution(distribution, constraint, name)
+
+########################################################################
+############################# Running GNKI #############################
+########################################################################
+
+# EKP parameters
+N_ens = 50
+N_iter = 20 
+tolerance = 1.0
+
+rng_seed = 2498
+
+rng = MersenneTwister(rng_seed)
+
+# initial parameters: N_params x N_ens
+initial_params = construct_initial_ensemble(rng, prior, N_ens)
+
+method = Inversion()
+
+@info "Ensemble size: $(N_ens)"
+ekpobj = EKP.EnsembleKalmanProcess(
+    initial_params,
+    y,
+    obs_noise_cov,
+    method;
+    rng = copy(rng),
+    verbose = true,    
+)
+
+count = 0
+n_iter = [0]
+for i in 1:N_iter
+    params_i = get_ϕ_final(prior, ekpobj)
+    
+    # If RMSE convergence criteria is not satisfied 
+    G_ens = hcat(
+        [
+            lorenz_forward(
+                EnsembleMemberConfig(params_i[:, j]),
+                (x0 .+ ic_cov_sqrt * rand(rng, Normal(0.0, 1.0), nx, N_ens))[:, j],
+                lorenz_config_settings,
+                observation_config,
+            ) for j in 1:N_ens
+                ]...,
+    )
+    # Update 
+    terminate = EKP.update_ensemble!(ekpobj, G_ens)
+    if !isnothing(terminate)
+        n_iter[1] = i-1
+        break
+    end
+end
+final_ensemble = get_ϕ_final(prior, ekpobj)
+
+# Output figure save directory
+homedir = pwd()
+println(homedir)
+figure_save_directory = homedir * "/output/"
+data_save_directory = homedir * "/output/"
+if ~isdir(figure_save_directory)
+    mkdir(figure_save_directory)
+end
+if ~isdir(data_save_directory)
+    mkdir(data_save_directory)
+end
+
+# Create plots
+p1 = plot(
+    range(0, nx - 1, step = 1),
+    [gamma mean(final_ensemble,dims=2)],
+    ribbon = 2*sqrt.(diag(obs_noise_cov)),
+    label = ["solution" "EKI"],
+    color = [:black :lightgreen],
+    linewidth = 2,
+    xlabel = "Spatial index",
+    ylabel = "Gamma",
+    title = "Optimized parameters for ensemble size = 50",
+    show = true,
+)
+show(p1)
+savefig(p1, figure_save_directory * "solution_spatial_dep_ens$(N_ens).png")
+
+# save objects
+save(
+    joinpath(data_save_directory, "ekp_spatial_dep.jld2"),
+    "ekpobj",
+    ekpobj,
+)
+save(
+    joinpath(data_save_directory, "priors_spatial_dep.jld2"),
+    "prior",
+    prior,
+)
+
+u_stored = EKP.get_u(ekpobj, return_array = false)
+g_stored = EKP.get_g(ekpobj, return_array = false)
+
+
+save(
+    joinpath(data_save_directory, "calibrate_results_spatial_dep.jld2"),
+    "inputs",
+    u_stored,
+    "outputs",
+    g_stored,
+    "truth_sample",
+    y,
+    "truth_sample_mean",
+    model_out_y,
+    "truth_input_constrained",
+    gamma,
+)

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -181,29 +181,24 @@ observation_config = ObservationConfig(T_start, T_end)
 model_out_y = lorenz_forward(true_parameters, x0, lorenz_config_settings, observation_config)
 
 #Observation covariance
-# [Don't need to do this bit really] - initial condition perturbations
-covT = 1000.0 
-cov_solve = lorenz_solve(true_parameters, x0, LorenzConfig(dt, covT))
-ic_cov = 0.1 * cov(cov_solve, dims = 2)
-ic_cov_sqrt = sqrt(ic_cov)
-
 n_samples = 200
+shuffled_ids = shuffle(Int(floor(size(x_spun_up,2)/2)):size(x_spun_up,2))
+x_on_attractor = x_spun_up[:,shuffled_ids[1:n_samples]] # randomly select points from second half of spin up
+
 y_ens = hcat(
     [
         lorenz_forward(
             true_parameters,
-            (x0 .+ ic_cov_sqrt * randn(rng_i, nx)),
+            x_on_attractor[:,j], 
             lorenz_config_settings,
             observation_config,
         ) for j in 1:n_samples
     ]...,
 )
 
-# estimate noise from IC-effect + R
+# estimate noise as the variability of these pushed-forward samples on the attractor
 obs_noise_cov = cov(y_ens, dims = 2)
 y = y_ens[:, 1]
-
-
 
 pl = 2.0
 psig = 3.0

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -164,7 +164,7 @@ dt = 0.01  #time step
 T_long = 1000.0  #total time 
 spinup_config = LorenzConfig(dt, T_long)
 x_initial = randn(rng_i, nx)
-x_spun_up = lorenz_solve(true_parameters, x_initial, spinup_config) 
+x_spun_up = lorenz_solve(true_parameters, x_initial, spinup_config)
 x0 = x_spun_up[:, end]  #last element of the run is the initial condition for creating the data
 
 
@@ -174,7 +174,7 @@ ny = nx * 2   #number of data points
 lorenz_config_settings = LorenzConfig(dt, T)
 
 # construct how we compute Observations
-T_start = 4.0  
+T_start = 4.0
 T_end = T
 observation_config = ObservationConfig(T_start, T_end)
 
@@ -182,17 +182,13 @@ model_out_y = lorenz_forward(true_parameters, x0, lorenz_config_settings, observ
 
 #Observation covariance
 n_samples = 200
-shuffled_ids = shuffle(Int(floor(size(x_spun_up,2)/2)):size(x_spun_up,2))
-x_on_attractor = x_spun_up[:,shuffled_ids[1:n_samples]] # randomly select points from second half of spin up
+shuffled_ids = shuffle(Int(floor(size(x_spun_up, 2) / 2)):size(x_spun_up, 2))
+x_on_attractor = x_spun_up[:, shuffled_ids[1:n_samples]] # randomly select points from second half of spin up
 
 y_ens = hcat(
     [
-        lorenz_forward(
-            true_parameters,
-            x_on_attractor[:,j], 
-            lorenz_config_settings,
-            observation_config,
-        ) for j in 1:n_samples
+        lorenz_forward(true_parameters, x_on_attractor[:, j], lorenz_config_settings, observation_config) for
+        j in 1:n_samples
     ]...,
 )
 

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -238,7 +238,7 @@ method = Inversion()
 ekpobj = EKP.EnsembleKalmanProcess(initial_params, y, obs_noise_cov, method; rng = copy(rng), verbose = true)
 
 count = 0
-n_iter = [0]
+n_iter = 0
 for i in 1:N_iter
     params_i = get_ϕ_final(prior, ekpobj)
 
@@ -256,7 +256,7 @@ for i in 1:N_iter
     # Update 
     terminate = EKP.update_ensemble!(ekpobj, G_ens)
     if !isnothing(terminate)
-        n_iter[1] = i - 1
+        n_iter = i - 1
         break
     end
 end

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -296,7 +296,7 @@ savefig(hm, joinpath(figure_save_directory, "spun_up_heatmap.pdf"))
 using Plots.Measures
 gr(size = (2 * 1.6 * 600, 600), guidefontsize = 18, tickfontsize = 16, legendfontsize = 16)
 p1 = plot(
-    range(0, nx-1, step = 1),
+    range(0, nx - 1, step = 1),
     [gamma mean(final_ensemble, dims = 2)],
     label = ["solution" "EKI"],
     color = [:black :lightgreen],
@@ -318,15 +318,9 @@ p2 = plot(
     ylabel = "State mean/std output)",
     left_margin = 15mm,
     bottom_margin = 15mm,
-    xticks= (Int.(0:10:ny), [0,10,20,30,(40,0),10,20,30,40])
+    xticks = (Int.(0:10:ny), [0, 10, 20, 30, (40, 0), 10, 20, 30, 40]),
 )
-plot!(p2,
-      1:length(y),
-      get_g_mean_final(ekpobj),
-      label = "mean-final-output",
-      color = :lightgreen,
-      linewidth = 4,
-)
+plot!(p2, 1:length(y), get_g_mean_final(ekpobj), label = "mean-final-output", color = :lightgreen, linewidth = 4)
 
 l = @layout [a b]
 plt = plot(p1, p2, layout = l)

--- a/examples/Lorenz/calibrate_spatial_dep.jl
+++ b/examples/Lorenz/calibrate_spatial_dep.jl
@@ -165,6 +165,8 @@ x_spun_up = lorenz_solve(true_parameters, x_initial, picking_initial_condition) 
 
 #intital condition used for the data
 x0 = x_spun_up[:, end]  #last element of the run is the initial condition for creating the data
+
+
 #Creating my sythetic data
 T = 104.0
 ny = nx * 2   #number of data points
@@ -195,10 +197,10 @@ y_ens = hcat(
     [
         lorenz_forward(
             true_parameters,
-            (x0 .+ ic_cov_sqrt * rand(rng, Normal(0.0, 1.0), nx, n_samples))[:, j],
+            (x0 .+ ic_cov_sqrt * rand(rng_i, Normal(0.0, 1.0), nx, n_samples))[:, j],
             lorenz_config_settings,
             observation_config,
-        ) for j in 1:N_ens
+        ) for j in 1:n_samples
             ]...,
 )
 

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -102,7 +102,7 @@ function main()
                 prediction_type = pred_type,
                 noise_learn = false,
             )
-        elseif case ∈ ["RF-scalar", "RF-scalar-diagin"]
+        elseif case == "RF-scalar", "RF-scalar-diagin"
             overrides = Dict(
                 "verbose" => true,
                 "scheduler" => DataMisfitController(terminate_at = 100.0),
@@ -117,54 +117,6 @@ function main()
             mlt = ScalarRandomFeatureInterface(
                 n_features,
                 n_params,
-                rng = rng,
-                kernel_structure = kernel_structure,
-                optimizer_options = overrides,
-            )
-        elseif case ∈ ["RF-vector-svd-diag", "RF-vector-nosvd-diag", "RF-vector-svd-nondiag", "RF-vector-nosvd-nondiag"]
-            overrides = Dict(
-                "verbose" => true,
-                "scheduler" => DataMisfitController(terminate_at = 1e8),
-                "cov_sample_multiplier" => 0.1,
-                "n_features_opt" => 100,
-                "n_iteration" => 10,
-                "train_fraction" => 0.9,
-                "n_ensemble" => 20,
-            )
-            # do we want to assume that the outputs are decorrelated in the machine-learning problem?
-            kernel_structure =
-                case ∈ ["RF-vector-svd-diag", "RF-vector-nosvd-diag"] ?
-                SeparableKernel(LowRankFactor(2, nugget), DiagonalFactor(nugget)) :
-                SeparableKernel(LowRankFactor(2, nugget), LowRankFactor(2, nugget))
-            n_features = 500
-
-            mlt = VectorRandomFeatureInterface(
-                n_features,
-                n_params,
-                output_dim,
-                rng = rng,
-                kernel_structure = kernel_structure,
-                optimizer_options = overrides,
-            )
-        elseif case ∈ ["RF-vector-svd-nonsep"]
-            overrides = Dict(
-                "verbose" => true,
-                "scheduler" => DataMisfitController(terminate_at = 100.0),
-                "cov_sample_multiplier" => 0.1,
-                "n_features_opt" => 100,
-                "n_iteration" => 5,
-                "train_fraction" => 0.98,
-                "n_ensemble" => 40,
-                "n_cross_val_sets" => 2,
-                "localization" => Localizers.SECNice(),
-            )
-            kernel_structure = NonseparableKernel(LowRankFactor(1, nugget))
-            n_features = 500
-
-            mlt = VectorRandomFeatureInterface(
-                n_features,
-                n_params,
-                output_dim,
                 rng = rng,
                 kernel_structure = kernel_structure,
                 optimizer_options = overrides,

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -296,7 +296,7 @@ function main()
 
         # Save data
         save(
-            joinpath(data_save_directory, "posterior_*case.jld2"),
+            joinpath(data_save_directory, "posterior_$(case).jld2"),
             "posterior",
             posterior,
             "priors",

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -102,7 +102,7 @@ function main()
                 prediction_type = pred_type,
                 noise_learn = false,
             )
-        elseif case == "RF-scalar", "RF-scalar-diagin"
+        elseif case == "RF-scalar"
             overrides = Dict(
                 "verbose" => true,
                 "scheduler" => DataMisfitController(terminate_at = 100.0),

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -40,7 +40,7 @@ function main()
         "GP", # SLOW
         "RF-scalar", # diagonalize, train scalar RF, don't asume diag inputs
         "RF-vector-svd-diag", # inaccurate
-        "RF-vector-svd-nondiag", 
+        "RF-vector-svd-nondiag",
         "RF-vector-svd-nonsep",
     ]
 
@@ -94,7 +94,7 @@ function main()
         # choice of machine-learning tool in the emulation stage
         nugget = 0.001
         if case == "GP"
-            gppackage = Emulators.GPJL() 
+            gppackage = Emulators.GPJL()
             pred_type = Emulators.YType()
             mlt = GaussianProcess(
                 gppackage;

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -35,7 +35,7 @@ end
 
 
 function main()
-    
+
     cases = [
         "GP", # VERY SLOW DO NOT RUN
         "RF-scalar", # diagonalize, train scalar RF, don't asume diag inputs
@@ -52,7 +52,7 @@ function main()
         println("case: ", case)
         min_iter = 1
         max_iter = 6 # number of EKP iterations to use data from is at most this
-        
+
         # we do not want termination, as our priors have relatively little interpretation
 
         ####
@@ -60,7 +60,7 @@ function main()
         exp_name = "Lorenz_histogram_spatial_dep"
         rng_seed = 44011
         rng = Random.MersenneTwister(rng_seed)
-        
+
         # loading relevant data
         homedir = pwd()
         println(homedir)
@@ -72,11 +72,7 @@ function main()
             joinpath(data_save_directory, "calibrate_results_spatial_dep.jld2"),
         ]
         if !isfile(data_save_files[1])
-            throw(
-                ErrorException(
-                    "data files not found. \n First run: \n > julia --project calibrate_spatial_dep.jl",
-                ),
-            )
+            throw(ErrorException("data files not found. \n First run: \n > julia --project calibrate_spatial_dep.jl"))
         end
 
         ekpobj = load(data_save_files[1])["ekpobj"]
@@ -109,10 +105,10 @@ function main()
         elseif case ∈ ["RF-scalar", "RF-scalar-diagin"]
             overrides = Dict(
                 "verbose" => true,
-            "scheduler" => DataMisfitController(terminate_at = 100.0),
-            "cov_sample_multiplier" => 1.0,
-            "n_iteration" => 8,
-        )
+                "scheduler" => DataMisfitController(terminate_at = 100.0),
+                "cov_sample_multiplier" => 1.0,
+                "n_iteration" => 8,
+            )
             n_features = 100
             kernel_structure =
                 case == "RF-scalar-diagin" ? SeparableKernel(DiagonalFactor(nugget), OneDimFactor()) :
@@ -125,14 +121,14 @@ function main()
                 optimizer_options = overrides,
             )
         elseif case ∈ ["RF-vector-svd-diag", "RF-vector-nosvd-diag", "RF-vector-svd-nondiag", "RF-vector-nosvd-nondiag"]
-             overrides = Dict(
-                 "verbose" => true,
-                 "scheduler" => DataMisfitController(terminate_at = 1e8),
-                 "cov_sample_multiplier" => 0.1,
-                 "n_features_opt" => 100,
-                 "n_iteration" => 10,
-                 "train_fraction" => 0.9,
-                 "n_ensemble" => 20,
+            overrides = Dict(
+                "verbose" => true,
+                "scheduler" => DataMisfitController(terminate_at = 1e8),
+                "cov_sample_multiplier" => 0.1,
+                "n_features_opt" => 100,
+                "n_iteration" => 10,
+                "train_fraction" => 0.9,
+                "n_ensemble" => 20,
             )
             # do we want to assume that the outputs are decorrelated in the machine-learning problem?
             kernel_structure =
@@ -158,12 +154,12 @@ function main()
                 "n_iteration" => 5,
                 "train_fraction" => 0.98,
                 "n_ensemble" => 40,
-                "n_cross_val_sets" =>2,
-                "localization" => Localizers.SECNice()
+                "n_cross_val_sets" => 2,
+                "localization" => Localizers.SECNice(),
             )
             kernel_structure = NonseparableKernel(LowRankFactor(1, nugget))
             n_features = 500
-            
+
             mlt = VectorRandomFeatureInterface(
                 n_features,
                 n_params,
@@ -285,16 +281,16 @@ function main()
             mapslices(x -> transform_unconstrained_to_constrained(posterior, x), posterior_samples, dims = 1)
 
         # marginal histogram
-        pp = plot(priors, c=:gray)
+        pp = plot(priors, c = :gray)
         plot!(pp, posterior)
-        for (i,sp) in enumerate(pp.subplots)
-            vline!(sp, [truth_params_constrained[i]], lc=:black, lw=4)
-            vline!(sp, [get_ϕ_mean_final(priors, ekpobj)[i]], lc=:magenta, lw=4)
+        for (i, sp) in enumerate(pp.subplots)
+            vline!(sp, [truth_params_constrained[i]], lc = :black, lw = 4)
+            vline!(sp, [get_ϕ_mean_final(priors, ekpobj)[i]], lc = :magenta, lw = 4)
         end
         figpath = joinpath(figure_save_directory, "posterior_hist_" * case)
-        savefig(figpath*".png")
+        savefig(figpath * ".png")
         figpath = joinpath(figure_save_directory, "posterior_hist_" * case)
-        savefig(figpath*".pdf")
+        savefig(figpath * ".pdf")
 
         # Save data
         save(

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -1,0 +1,306 @@
+# Import modules
+include(joinpath(@__DIR__, "..", "ci", "linkfig.jl"))
+
+# Import modules
+using Distributions  # probability distributions and associated functions
+using LinearAlgebra
+ENV["GKSwstype"] = "100"
+using StatsPlots
+using Plots
+using Random
+using JLD2
+
+# CES 
+using CalibrateEmulateSample.Emulators
+using CalibrateEmulateSample.MarkovChainMonteCarlo
+using CalibrateEmulateSample.Utilities
+using CalibrateEmulateSample.EnsembleKalmanProcesses
+using CalibrateEmulateSample.ParameterDistributions
+using CalibrateEmulateSample.DataContainers
+
+function get_standardizing_factors(data::Array{FT, 2}) where {FT}
+    # Input: data size: N_data x N_ensembles
+    # Ensemble median of the data
+    norm_factor = median(data, dims = 2)
+    return norm_factor
+end
+
+function get_standardizing_factors(data::Array{FT, 1}) where {FT}
+    # Input: data size: N_data*N_ensembles (splatted)
+    # Ensemble median of the data
+    norm_factor = median(data)
+    return norm_factor
+end
+
+
+function main()
+    
+    cases = [
+        "GP", # diagonalize, train scalar GP, assume diag inputs
+        "RF-scalar-diagin", # diagonalize, train scalar RF, assume diag inputs (most comparable to GP)
+        "RF-scalar", # diagonalize, train scalar RF, don't asume diag inputs
+        "RF-vector-svd-diag",
+        "RF-vector-svd-nondiag",
+        "RF-vector-nosvd-diag",
+        "RF-vector-nosvd-nondiag",
+        "RF-vector-svd-nonsep",
+    ]
+
+    #### CHOOSE YOUR CASE: 
+    mask = [3] # 1:8 # e.g. 1:8 or [7]
+    for (case) in cases[mask]
+
+
+        println("case: ", case)
+        min_iter = 1
+        max_iter = 5 # number of EKP iterations to use data from is at most this
+        overrides = Dict(
+#            "verbose" => true,
+            "scheduler" => DataMisfitController(terminate_at = 100.0),
+            "cov_sample_multiplier" => 1.0,
+            "n_iteration" => 5,
+        )
+        # we do not want termination, as our priors have relatively little interpretation
+
+        ####
+
+        exp_name = "Lorenz_histogram_spatial_dep"
+        rng_seed = 44011
+        rng = Random.MersenneTwister(rng_seed)
+        
+        # loading relevant data
+        homedir = pwd()
+        println(homedir)
+        figure_save_directory = joinpath(homedir, "output/")
+        data_save_directory = joinpath(homedir, "output/")
+        data_save_files = [
+            joinpath(data_save_directory, "ekp_spatial_dep.jld2"),
+            joinpath(data_save_directory, "priors_spatial_dep.jld2"),
+            joinpath(data_save_directory, "calibrate_results_spatial_dep.jld2"),
+        ]
+        if !isfile(data_save_files[1])
+            throw(
+                ErrorException(
+                    "data files not found. \n First run: \n > julia --project calibrate_spatial_dep.jl",
+                ),
+            )
+        end
+
+        ekpobj = load(data_save_files[1])["ekpobj"]
+        priors = load(data_save_files[2])["prior"]
+        truth_sample_mean = load(data_save_files[3])["truth_sample_mean"]
+        truth_sample = load(data_save_files[3])["truth_sample"]
+        truth_params_constrained = load(data_save_files[3])["truth_input_constrained"] #true parameters in constrained space
+        truth_params = transform_constrained_to_unconstrained(priors, truth_params_constrained)
+        Γy = get_obs_noise_cov(ekpobj)
+
+
+        n_params = length(truth_params) # "input dim"
+        output_dim = size(Γy, 1)
+        ###
+        ###  Emulate: Gaussian Process Regression
+        ###
+
+        # Emulate-sample settings
+        # choice of machine-learning tool in the emulation stage
+        nugget = 0.001
+        if case == "GP"
+            gppackage = Emulators.GPJL()
+            pred_type = Emulators.YType()
+            mlt = GaussianProcess(
+                gppackage;
+                kernel = nothing, # use default squared exponential kernel
+                prediction_type = pred_type,
+                noise_learn = false,
+            )
+        elseif case ∈ ["RF-scalar", "RF-scalar-diagin"]
+            n_features = 100
+            kernel_structure =
+                case == "RF-scalar-diagin" ? SeparableKernel(DiagonalFactor(nugget), OneDimFactor()) :
+                SeparableKernel(LowRankFactor(2, nugget), OneDimFactor())
+            mlt = ScalarRandomFeatureInterface(
+                n_features,
+                n_params,
+                rng = rng,
+                kernel_structure = kernel_structure,
+                optimizer_options = overrides,
+            )
+        elseif case ∈ ["RF-vector-svd-diag", "RF-vector-nosvd-diag", "RF-vector-svd-nondiag", "RF-vector-nosvd-nondiag"]
+            # do we want to assume that the outputs are decorrelated in the machine-learning problem?
+            kernel_structure =
+                case ∈ ["RF-vector-svd-diag", "RF-vector-nosvd-diag"] ?
+                SeparableKernel(LowRankFactor(2, nugget), DiagonalFactor(nugget)) :
+                SeparableKernel(LowRankFactor(2, nugget), LowRankFactor(3, nugget))
+            n_features = 500
+
+            mlt = VectorRandomFeatureInterface(
+                n_features,
+                n_params,
+                output_dim,
+                rng = rng,
+                kernel_structure = kernel_structure,
+                optimizer_options = overrides,
+            )
+        elseif case ∈ ["RF-vector-svd-nonsep"]
+            kernel_structure = NonseparableKernel(LowRankFactor(3, nugget))
+            n_features = 500
+
+            mlt = VectorRandomFeatureInterface(
+                n_features,
+                n_params,
+                output_dim,
+                rng = rng,
+                kernel_structure = kernel_structure,
+                optimizer_options = overrides,
+            )
+        end
+
+        # Standardize the output data
+        # Use median over all data since all data are the same type
+        truth_sample_norm = vcat(truth_sample...)
+        norm_factor = get_standardizing_factors(truth_sample_norm)
+        #norm_factor = vcat(norm_factor...)
+        norm_factor = fill(norm_factor, size(truth_sample))
+
+        # Get training points from the EKP iteration number in the second input term  
+        N_iter = min(max_iter, length(get_u(ekpobj)) - 1) # number of paired iterations taken from EKP
+        min_iter = min(max_iter, max(1, min_iter))
+        input_output_pairs = Utilities.get_training_points(ekpobj, min_iter:(N_iter - 1))
+        input_output_pairs_test = Utilities.get_training_points(ekpobj, N_iter:(length(get_u(ekpobj)) - 1)) #  "next" iterations
+        # Save data
+        @save joinpath(data_save_directory, "input_output_pairs.jld2") input_output_pairs
+
+        # plot training points in constrained space
+        if case == cases[mask[1]]
+            gr(dpi = 300, size = (400, 400))
+            inputs_unconstrained = get_inputs(input_output_pairs)
+            inputs_constrained = transform_unconstrained_to_constrained(priors, inputs_unconstrained)
+            p = plot(
+                title = "training points",
+                xlims = extrema(inputs_constrained[1, :]),
+                xaxis = "F",
+                yaxis = "A",
+                ylims = extrema(inputs_constrained[2, :]),
+            )
+            scatter!(p, inputs_constrained[1, :], inputs_constrained[2, :], color = :magenta, label = false)
+            inputs_test_unconstrained = get_inputs(input_output_pairs_test)
+            inputs_test_constrained = transform_unconstrained_to_constrained(priors, inputs_test_unconstrained)
+
+            scatter!(p, inputs_test_constrained[1, :], inputs_test_constrained[2, :], color = :black, label = false)
+
+            vline!(p, [truth_params_constrained[1]], linestyle = :dash, linecolor = :red, label = false)
+            hline!(p, [truth_params_constrained[2]], linestyle = :dash, linecolor = :red, label = false)
+            savefig(p, joinpath(figure_save_directory, "training_points.pdf"))
+            savefig(p, joinpath(figure_save_directory, "training_points.png"))
+        end
+
+        standardize = false
+        retained_svd_frac = 1.0
+        normalized = true
+        # do we want to use SVD to decorrelate outputs
+        decorrelate = case ∈ ["RF-vector-nosvd-diag", "RF-vector-nosvd-nondiag"] ? false : true
+
+
+        emulator = Emulator(
+            mlt,
+            input_output_pairs;
+            obs_noise_cov = Γy,
+            normalize_inputs = normalized,
+            standardize_outputs = standardize,
+            standardize_outputs_factors = norm_factor,
+            retained_svd_frac = retained_svd_frac,
+            decorrelate = decorrelate,
+        )
+        optimize_hyperparameters!(emulator)
+
+        # Check how well the Gaussian Process regression predicts on the
+        # true parameters
+        #if retained_svd_frac==1.0
+        y_mean, y_var = Emulators.predict(emulator, reshape(truth_params, :, 1), transform_to_real = true)
+        y_mean_test, y_var_test =
+            Emulators.predict(emulator, get_inputs(input_output_pairs_test), transform_to_real = true)
+
+        println("ML prediction on true parameters: ")
+        println(vec(y_mean))
+        println("true data: ")
+        println(truth_sample) # what was used as truth
+        println(" ML predicted standard deviation")
+        println(sqrt.(diag(y_var[1], 0)))
+        println("ML MSE (truth): ")
+        println(mean((truth_sample - vec(y_mean)) .^ 2))
+        println("ML MSE (next ensemble): ")
+        println(mean((get_outputs(input_output_pairs_test) - y_mean_test) .^ 2))
+
+        #end
+        ###
+        ###  Sample: Markov Chain Monte Carlo
+        ###
+        # initial values
+        u0 = vec(mean(get_inputs(input_output_pairs), dims = 2))
+        println("initial parameters: ", u0)
+
+        # First let's run a short chain to determine a good step size
+        mcmc = MCMCWrapper(RWMHSampling(), truth_sample, priors, emulator; init_params = u0)
+        new_step = optimize_stepsize(mcmc; init_stepsize = 0.1, N = 2000, discard_initial = 0)
+
+        # Now begin the actual MCMC
+        println("Begin MCMC - with step size ", new_step)
+        chain = MarkovChainMonteCarlo.sample(mcmc, 100_000; stepsize = new_step, discard_initial = 2_000)
+
+        posterior = MarkovChainMonteCarlo.get_posterior(mcmc, chain)
+
+        post_mean = mean(posterior)
+        post_cov = cov(posterior)
+        println("post_mean")
+        println(post_mean)
+        println("post_cov")
+        println(post_cov)
+        println("D util")
+        println(det(inv(post_cov)))
+        println(" ")
+
+        param_names = get_name(posterior)
+
+        posterior_samples = vcat([get_distribution(posterior)[name] for name in get_name(posterior)]...) #samples are columns
+        constrained_posterior_samples =
+            mapslices(x -> transform_unconstrained_to_constrained(posterior, x), posterior_samples, dims = 1)
+
+        # marginal histogram
+        pp = plot(prior)
+        plot!(pp, posterior)
+        for (i,sp) in enumerate(pp.subplots)
+            vline!(sp, [gamma[i]], lc="black", lw=4)
+            vline!(sp, [get_ϕ_mean_final(ekpobj)[i]], lc="magenta", lw=4)
+        end
+        figpath = joinpath(figure_save_directory, "posterior_hist" * case)
+        savefig(figpath*".png")
+        figpath = joinpath(figure_save_directory, "posterior_hist" * case)
+        savefig(figpath*".pdf")
+        
+        #=
+        gr(dpi = 300, size = (2400, 2400))
+        p = cornerplot(permutedims(constrained_posterior_samples, (2, 1)), label = param_names, compact = true)
+        plot!(p.subplots[1], [truth_params_constrained[1]], seriestype = "vline", w = 1.5, c = :steelblue, ls = :dash) # vline on top histogram
+        plot!(p.subplots[3], [truth_params_constrained[2]], seriestype = "hline", w = 1.5, c = :steelblue, ls = :dash) # hline on right histogram
+        plot!(p.subplots[2], [truth_params_constrained[1]], seriestype = "vline", w = 1.5, c = :steelblue, ls = :dash) # v & h line on scatter.
+        plot!(p.subplots[2], [truth_params_constrained[2]], seriestype = "hline", w = 1.5, c = :steelblue, ls = :dash)
+        figpath = joinpath(figure_save_directory, "posterior_2d-" * case * ".pdf")
+        savefig(figpath)
+        figpath = joinpath(figure_save_directory, "posterior_2d-" * case * ".png")
+        savefig(figpath)
+        =#
+
+        # Save data
+        save(
+            joinpath(data_save_directory, "posterior.jld2"),
+            "posterior",
+            posterior,
+            "input_output_pairs",
+            input_output_pairs,
+            "truth_params",
+            truth_params,
+        )
+    end
+end
+
+main()

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -270,7 +270,7 @@ function main()
         plot!(pp, posterior)
         for (i,sp) in enumerate(pp.subplots)
             vline!(sp, [gamma[i]], lc="black", lw=4)
-            vline!(sp, [get_ϕ_mean_final(ekpobj)[i]], lc="magenta", lw=4)
+            vline!(sp, [get_ϕ_mean_final(prior, ekpobj)[i]], lc="magenta", lw=4)
         end
         figpath = joinpath(figure_save_directory, "posterior_hist" * case)
         savefig(figpath*".png")

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -74,7 +74,6 @@ function main()
 
         ekpobj = load(data_save_files[1])["ekpobj"]
         priors = load(data_save_files[2])["prior"]
-        truth_sample_mean = load(data_save_files[3])["truth_sample_mean"]
         truth_sample = load(data_save_files[3])["truth_sample"]
         truth_params_constrained = load(data_save_files[3])["truth_input_constrained"] #true parameters in constrained space
         truth_params = transform_constrained_to_unconstrained(priors, truth_params_constrained)
@@ -109,8 +108,7 @@ function main()
             )
             n_features = 200
             kernel_structure =
-                case == "RF-scalar-diagin" ? SeparableKernel(DiagonalFactor(nugget), OneDimFactor()) :
-                SeparableKernel(LowRankFactor(2, nugget), OneDimFactor())
+                case == SeparableKernel(LowRankFactor(2, nugget), OneDimFactor())
             mlt = ScalarRandomFeatureInterface(
                 n_features,
                 n_params,
@@ -118,6 +116,8 @@ function main()
                 kernel_structure = kernel_structure,
                 optimizer_options = overrides,
             )
+        else
+            throw(ArgumentError("case $(case) not recognised, please choose from the list $(cases)"
         end
 
         # Standardize the output data
@@ -163,7 +163,7 @@ function main()
         retained_svd_frac = 0.99 # keep 99% of the singular values
         normalized = true
         # do we want to use SVD to decorrelate outputs
-        decorrelate = case ∈ ["RF-vector-nosvd-diag", "RF-vector-nosvd-nondiag"] ? false : true
+        decorrelate = true
 
 
         emulator = Emulator(

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -39,13 +39,10 @@ function main()
     cases = [
         "GP", # SLOW
         "RF-scalar", # diagonalize, train scalar RF, don't asume diag inputs
-        "RF-vector-svd-diag", # inaccurate
-        "RF-vector-svd-nondiag",
-        "RF-vector-svd-nonsep",
     ]
 
     #### CHOOSE YOUR CASE: 
-    mask = [2]# 1:8 # e.g. 1:8 or [7]
+    mask = [2]# 1:1 # e.g. 1:2 or [2]
     for (case) in cases[mask]
 
 

--- a/examples/Lorenz/emulate_sample_spatial_dep.jl
+++ b/examples/Lorenz/emulate_sample_spatial_dep.jl
@@ -107,8 +107,7 @@ function main()
                 "n_features_opt" => 40,
             )
             n_features = 200
-            kernel_structure =
-                case == SeparableKernel(LowRankFactor(2, nugget), OneDimFactor())
+            kernel_structure = SeparableKernel(LowRankFactor(2, nugget), OneDimFactor())
             mlt = ScalarRandomFeatureInterface(
                 n_features,
                 n_params,
@@ -117,7 +116,7 @@ function main()
                 optimizer_options = overrides,
             )
         else
-            throw(ArgumentError("case $(case) not recognised, please choose from the list $(cases)"
+            throw(ArgumentError("case $(case) not recognised, please choose from the list $(cases)"))
         end
 
         # Standardize the output data
@@ -240,7 +239,6 @@ function main()
         end
         figpath = joinpath(figure_save_directory, "posterior_hist_" * case)
         savefig(figpath * ".png")
-        figpath = joinpath(figure_save_directory, "posterior_hist_" * case)
         savefig(figpath * ".pdf")
 
         # Save data

--- a/examples/Lorenz/plot_spatial_dep.jl
+++ b/examples/Lorenz/plot_spatial_dep.jl
@@ -113,5 +113,4 @@ plot!(
 
 figpath = joinpath(figure_save_directory, "posterior_ribbons_" * case)
 savefig(figpath * ".png")
-figpath = joinpath(figure_save_directory, "posterior_ribbons_" * case)
 savefig(figpath * ".pdf")

--- a/examples/Lorenz/plot_spatial_dep.jl
+++ b/examples/Lorenz/plot_spatial_dep.jl
@@ -1,0 +1,123 @@
+# some context values (from calibrate_spatial_dep.jl)
+
+# some context calues from emulate_sample_spatial_dep.jl
+cases = [
+        "GP", # SLOW
+        "RF-scalar", # diagonalize, train scalar RF, don't asume diag inputs
+        "RF-vector-svd-diag", # inaccurate
+        "RF-vector-svd-nondiag", 
+        "RF-vector-svd-nonsep",
+    ]
+case = cases[2]
+
+# load packages
+# CES 
+
+using Random
+using JLD2
+using Statistics
+using LinearAlgebra
+
+using Plots
+using Plots.Measures
+
+using CalibrateEmulateSample.EnsembleKalmanProcesses
+using CalibrateEmulateSample.EnsembleKalmanProcesses.ParameterDistributions
+const EKP = EnsembleKalmanProcesses
+
+# load
+homedir = pwd()
+println(homedir)
+figure_save_directory = joinpath(homedir, "output/")
+data_save_directory = joinpath(homedir, "output/")
+data_file = joinpath(data_save_directory, "posterior_$(case).jld2")
+truth_params = load(data_file)["truth_params_constrained"]
+final_params = load(data_file)["final_params_constrained"]
+posterior = load(data_file)["posterior"]
+
+ekp_file = joinpath(data_save_directory, "ekp_spatial_dep.jld2")
+ekpobj = load(ekp_file)["ekpobj"]
+N_ens = get_N_ens(ekpobj)
+
+# get samples and quantiles from posterior
+param_names = get_name(posterior)
+posterior_samples = vcat([get_distribution(posterior)[name] for name in get_name(posterior)]...) #samples are columns
+constrained_posterior_samples =
+    mapslices(x -> transform_unconstrained_to_constrained(posterior, x), posterior_samples, dims = 1)
+
+quantiles = reduce(hcat,[quantile(row, [0.05, 0.5, 0.95]) for row in eachrow(constrained_posterior_samples)])' # rows are quantiles for row of posterior samples
+
+
+# plot - EKI results
+gr(size = (2 * 1.6 * 600, 600), guidefontsize = 18, tickfontsize = 16, legendfontsize = 16)
+p1 = plot(
+    range(0, nx-1, step = 1),
+    [truth_params  final_params],
+    label = ["solution" "EKI"],
+    color = [:black :lightgreen],
+    linewidth = 4,
+    xlabel = "Spatial index",
+    ylabel = "Forcing (input)",
+    left_margin = 15mm,
+    bottom_margin = 15mm,
+)
+
+p2 = plot(
+    1:length(y),
+    y,
+    ribbon = sqrt.(diag(get_obs_noise_cov(ekpobj))),
+    label = "data",
+    color = :black,
+    linewidth = 4,
+    xlabel = "Spatial index",
+    ylabel = "State mean/std output)",
+    left_margin = 15mm,
+    bottom_margin = 15mm,
+    xticks= (Int.(0:10:ny), [0,10,20,30,(40,0),10,20,30,40])
+)
+plot!(p2,
+      1:length(y),
+      get_g_mean_final(ekpobj),
+      label = "mean-final-output",
+      color = :lightgreen,
+      linewidth = 4,
+)
+
+l = @layout [a b]
+plt = plot(p1, p2, layout = l)
+
+savefig(plt, figure_save_directory * "solution_spatial_dep_ens$(N_ens).png")
+savefig(plt, figure_save_directory * "solution_spatial_dep_ens$(N_ens).pdf")
+
+
+# plot - UQ results
+
+gr(size = (1.6 * 600, 600), guidefontsize = 18, tickfontsize = 16, legendfontsize = 16)
+p1 = plot(
+    range(0, nx-1, step = 1),
+    [truth_params final_params],
+    label = ["solution" "EKI-opt"],
+    color = [:black :lightgreen],
+    linewidth = 4,
+    xlabel = "Spatial index",
+    ylabel = "Forcing (input)",
+    left_margin = 15mm,
+    bottom_margin = 15mm,
+)
+
+plot!(
+    p1,
+    range(0, nx-1, step = 1),
+    quantiles[:,2], # median of all vals
+    color = :blue,
+    label = "posterior",
+    linewidth = 4,
+    ribbon = [quantiles[:,2] - quantiles[:,1] quantiles[:,3] - quantiles[:,2]],
+    fillalpha = 0.1,
+)
+
+
+figpath = joinpath(figure_save_directory, "posterior_ribbons_" * case)
+savefig(figpath * ".png")
+figpath = joinpath(figure_save_directory, "posterior_ribbons_" * case)
+savefig(figpath * ".pdf")

--- a/examples/Lorenz/plot_spatial_dep.jl
+++ b/examples/Lorenz/plot_spatial_dep.jl
@@ -2,12 +2,12 @@
 
 # some context calues from emulate_sample_spatial_dep.jl
 cases = [
-        "GP", # SLOW
-        "RF-scalar", # diagonalize, train scalar RF, don't asume diag inputs
-        "RF-vector-svd-diag", # inaccurate
-        "RF-vector-svd-nondiag", 
-        "RF-vector-svd-nonsep",
-    ]
+    "GP", # SLOW
+    "RF-scalar", # diagonalize, train scalar RF, don't asume diag inputs
+    "RF-vector-svd-diag", # inaccurate
+    "RF-vector-svd-nondiag",
+    "RF-vector-svd-nonsep",
+]
 case = cases[2]
 
 # load packages
@@ -45,14 +45,14 @@ posterior_samples = vcat([get_distribution(posterior)[name] for name in get_name
 constrained_posterior_samples =
     mapslices(x -> transform_unconstrained_to_constrained(posterior, x), posterior_samples, dims = 1)
 
-quantiles = reduce(hcat,[quantile(row, [0.05, 0.5, 0.95]) for row in eachrow(constrained_posterior_samples)])' # rows are quantiles for row of posterior samples
+quantiles = reduce(hcat, [quantile(row, [0.05, 0.5, 0.95]) for row in eachrow(constrained_posterior_samples)])' # rows are quantiles for row of posterior samples
 
 
 # plot - EKI results
 gr(size = (2 * 1.6 * 600, 600), guidefontsize = 18, tickfontsize = 16, legendfontsize = 16)
 p1 = plot(
-    range(0, nx-1, step = 1),
-    [truth_params  final_params],
+    range(0, nx - 1, step = 1),
+    [truth_params final_params],
     label = ["solution" "EKI"],
     color = [:black :lightgreen],
     linewidth = 4,
@@ -73,15 +73,9 @@ p2 = plot(
     ylabel = "State mean/std output)",
     left_margin = 15mm,
     bottom_margin = 15mm,
-    xticks= (Int.(0:10:ny), [0,10,20,30,(40,0),10,20,30,40])
+    xticks = (Int.(0:10:ny), [0, 10, 20, 30, (40, 0), 10, 20, 30, 40]),
 )
-plot!(p2,
-      1:length(y),
-      get_g_mean_final(ekpobj),
-      label = "mean-final-output",
-      color = :lightgreen,
-      linewidth = 4,
-)
+plot!(p2, 1:length(y), get_g_mean_final(ekpobj), label = "mean-final-output", color = :lightgreen, linewidth = 4)
 
 l = @layout [a b]
 plt = plot(p1, p2, layout = l)
@@ -94,7 +88,7 @@ savefig(plt, figure_save_directory * "solution_spatial_dep_ens$(N_ens).pdf")
 
 gr(size = (1.6 * 600, 600), guidefontsize = 18, tickfontsize = 16, legendfontsize = 16)
 p1 = plot(
-    range(0, nx-1, step = 1),
+    range(0, nx - 1, step = 1),
     [truth_params final_params],
     label = ["solution" "EKI-opt"],
     color = [:black :lightgreen],
@@ -107,12 +101,12 @@ p1 = plot(
 
 plot!(
     p1,
-    range(0, nx-1, step = 1),
-    quantiles[:,2], # median of all vals
+    range(0, nx - 1, step = 1),
+    quantiles[:, 2], # median of all vals
     color = :blue,
     label = "posterior",
     linewidth = 4,
-    ribbon = [quantiles[:,2] - quantiles[:,1] quantiles[:,3] - quantiles[:,2]],
+    ribbon = [quantiles[:, 2] - quantiles[:, 1] quantiles[:, 3] - quantiles[:, 2]],
     fillalpha = 0.1,
 )
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- Streamlining and continuation of the example from EKP.jl.
- Run with some of the CES algorithms to assess performance, RF-scalar is most efficient so far.
- remove non-GP / RF-scalar options? Or find a working configuration.
### From Calibrate 
Heatmap of truth
![spun_up_heatmap](https://github.com/user-attachments/assets/ad8773b5-b042-4dad-b1c7-05da7ec86065)

the solution from 5 iterations of EKP, learning a sinusoidal forcing of states in L96 from time-averaged data (mean of state + std of state is observed):
![solution_spatial_dep_ens50](https://github.com/user-attachments/assets/40a8795b-d8e5-47b7-9f23-bb780a513918)

### From Emulate-Sample (RF-scalar) 
The posterior plot [0.05,0.5,0.95] quantiles plotted
![posterior_ribbons_RF-scalar](https://github.com/user-attachments/assets/75febed3-503b-46c3-b915-32dd984ec07b)





<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
