### PR TITLE
new predict method API, and reduced sampling in input space

### DIFF
--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -106,7 +106,7 @@ get_encoder_schedule(emulator::Emulator) = emulator.encoder_schedule
 
 """
 $(TYPEDEF)
-This can replace an `Emulator`, but stores the original forward map. The forward map must be definable as a function `f`. To apply `f` properly this object also builds and stores an encoder `E`  and a parameter distribution (i.e. the prior) containing physical constraints `c` .
+This can replace an `Emulator`, but stores the original forward map. The forward map must be definable as a function `f`. To apply `f` properly this object also builds and stores an encoder `E`  and a parameter distribution (i.e. the prior) containing physical constraints `c`.
 
 When predict() is called this map will call `E_{out}∘f∘c(x)`
 

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -33,8 +33,8 @@ abstract type MachineLearningTool end
 
 # include the different <: ML models
 
-include(joinpath("MachineLearningTools", "GaussianProcess.jl")) #for GaussianProcess
-include(joinpath("MachineLearningTools", "RandomFeature.jl")) # Random Freatures
+include(joinpath("MachineLearningTools","GaussianProcess.jl")) #for GaussianProcess
+include(joinpath("MachineLearningTools","RandomFeature.jl")) # Random Freatures
 # include(joinpath("MachineLearningTools","NeuralNetwork.jl"))
 # etc.
 
@@ -106,7 +106,7 @@ get_encoder_schedule(emulator::Emulator) = emulator.encoder_schedule
 
 """
 $(TYPEDEF)
-This can replace an `Emulator`, but stores the original forward map. The forward map must be definable as a function `f`. To apply `f` properly this object also builds and stores an encoder `E`  and a parameter distribution (i.e. the prior) containing physical constraints `c`.
+This can replace an `Emulator`, but stores the original forward map. The forward map must be definable as a function `f`. To apply `f` properly this object also builds and stores an encoder `E`  and a parameter distribution (i.e. the prior) containing physical constraints `c` .
 
 When predict() is called this map will call `E_{out}∘f∘c(x)`
 
@@ -116,7 +116,7 @@ $(TYPEDFIELDS)
 # Constructors:
 - `forward_map_wrapper(forward_map, prior, input_output_pairs; encoder_schedule=nothing, encoder_kwargs=NamedTuple())`
 """
-struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution}
+struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution} 
     "function that represents the forward map"
     forward_map::Function
     "a parameter distribution, containing transformations to constrain the forward map inputs"
@@ -388,7 +388,7 @@ function predict(
             return encoded_outputs, encoded_covariances_mat[1, :, :]
         end
     end
-
+    
 end
 
 ### Forward Map constructor and methods
@@ -455,20 +455,20 @@ function predict(
     # unlike the emulator, the forward map runs in the physical, decoded space. and must be encoded where necessary 
     prior = get_prior(fmw)
     forward_map = get_forward_map(fmw)
-    fm_unc = x -> forward_map(transform_unconstrained_to_constrained(prior, x))
+    fm_unc= x-> forward_map(transform_unconstrained_to_constrained(prior, x)) 
 
     decoded_outputs = reduce(hcat, map(fm_unc, eachcol(new_inputs))) # apply map and return: [out_dim x n_samples]
-
+    
     var_or_cov = (output_dim == 1) ? "var" : "cov"
     if transform_to_real
         # uncertainty returned is just `I` in encoded space
         decoded_cov = Matrix(decode_structure_matrix(fmw, I(output_dim), "out"))
-
-        decoded_covariances = zeros(eltype(decoded_outputs), output_dim, output_dim, size(decoded_outputs, 2))
-        for i in 1:size(decoded_covariances, 3)
+        
+        decoded_covariances = zeros(eltype(decoded_outputs), output_dim, output_dim, size(decoded_outputs,2))
+        for i in 1:size(decoded_covariances,3)
             decoded_covariances[:, :, i] .= decoded_cov
         end
-
+        
         if output_dim > 1
             return decoded_outputs, eachslice(decoded_covariances, dims = 3)
         else
@@ -477,16 +477,16 @@ function predict(
         end
 
     else # We encode
-        encoded_outputs = Matrix(encode_data(fmw, decoded_outputs, "out"))
-        encoded_output_dim = size(encoded_outputs, 1)
+        encoded_outputs = Matrix(encode_data(fmw, decoded_outputs ,"out"))
+        encoded_output_dim = size(encoded_outputs,1)
         encoded_cov = I(encoded_output_dim)
 
         encoded_covariances_mat =
-            zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_outputs, 2))
-        for i in 1:size(encoded_covariances_mat, 3)
+            zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_outputs,2))
+        for i in 1:size(encoded_covariances_mat,3)
             encoded_covariances_mat[:, :, i] = encoded_cov
         end
-
+        
         if encoded_output_dim > 1
             return encoded_outputs, eachslice(encoded_covariances_mat, dims = 3)
         else
@@ -496,4 +496,4 @@ function predict(
     end
 end
 
-end
+end 

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -245,11 +245,7 @@ function encode_data(
     encoder_schedule::VV,
     data::MorDC,
     in_or_out::AS,
-) where {
-    AS <: AbstractString,
-    MorDC <: Union{AbstractMatrix, DataContainer},
-    VV <: AbstractVector,
-}
+) where {AS <: AbstractString, MorDC <: Union{AbstractMatrix, DataContainer}, VV <: AbstractVector}
     if isa(data, AbstractMatrix)
         return get_data(encode_with_schedule(encoder_schedule, DataContainer(data), in_or_out))
     else
@@ -268,7 +264,7 @@ function encode_data(
 }
     return encode_data(get_encoder_schedule(em_or_fmw), data, in_or_out)
 end
-    
+
 
 """
 $(TYPEDSIGNATURES)
@@ -301,11 +297,7 @@ function decode_data(
     encoder_schedule::VV,
     data::MorDC,
     in_or_out::AS,
-) where {
-    AS <: AbstractString,
-    MorDC <: Union{AbstractMatrix, DataContainer},
-    VV <: AbstractVector,
-}
+) where {AS <: AbstractString, MorDC <: Union{AbstractMatrix, DataContainer}, VV <: AbstractVector}
     if isa(data, AbstractMatrix)
         return get_data(decode_with_schedule(encoder_schedule, DataContainer(data), in_or_out))
     else
@@ -345,7 +337,7 @@ function decode_structure_matrix(
 ) where {AS <: AbstractString, EorFMW <: Union{Emulator, ForwardMapWrapper}}
     return decode_structure_matrix(get_encoder_schedule(em_or_fmw), structure_mat, in_or_out)
 end
-    
+
 """
 $(TYPEDSIGNATURES)
 
@@ -509,12 +501,8 @@ function predict(
         # decode 
         decoded_inputs = Matrix(decode_data(fmw, new_inputs, "in"))
         # add sample from null space:
-        prior_samples = sample(prior, size(decoded_inputs,2))
-        null_samples = prior_samples - Matrix(decode_data(
-            fmw,
-            encode_data(fmw, prior_samples, "in"),
-            "in",
-        ))
+        prior_samples = sample(prior, size(decoded_inputs, 2))
+        null_samples = prior_samples - Matrix(decode_data(fmw, encode_data(fmw, prior_samples, "in"), "in"))
         decoded_inputs .+= null_samples
     else
         decoded_inputs = new_inputs

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -376,7 +376,7 @@ function predict(
     # note the logic below
     in_already_encoded = encode ∈ ["in", "in_and_out"]
     out_to_be_decoded = encode ∉ ["out", "in_and_out"]
-
+    
     # encode the new input data
     if !in_already_encoded
         encoded_inputs = encode_data(emulator, new_inputs, "in")

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -1,12 +1,14 @@
 module Emulators
 
 using ..DataContainers
+using ..Utilities
 import ..Utilities.encode_with_schedule
 import ..Utilities.decode_with_schedule
 import ..Utilities.encode_data
 import ..Utilities.decode_data
 import ..Utilities.encode_structure_matrix
 import ..Utilities.decode_structure_matrix
+
 
 using DocStringExtensions
 using Statistics
@@ -116,7 +118,7 @@ $(TYPEDFIELDS)
 # Constructors:
 - `forward_map_wrapper(forward_map, prior, input_output_pairs; encoder_schedule=nothing, encoder_kwargs=NamedTuple())`
 """
-struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution}
+struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution, NI <: NoiseInjector}
     "function that represents the forward map"
     forward_map::Function
     "a parameter distribution, containing transformations to constrain the forward map inputs"
@@ -127,6 +129,8 @@ struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistri
     encoded_io_pairs::PairedDataContainer{FT}
     "Store of the pipeline to encode (/decode) the data"
     encoder_schedule::VV
+    "For lossy encodings, this determines how to inject noise into the null-space upon decoding"
+    noise_injector::NI
 end
 """
 $(TYPEDSIGNATURES)
@@ -162,6 +166,13 @@ $(TYPEDSIGNATURES)
 Gets the `encoder_schedule` field of the `ForwardMapWrapper`
 """
 get_encoder_schedule(fmw::ForwardMapWrapper) = fmw.encoder_schedule
+
+"""
+$(TYPEDSIGNATURES)
+
+Gets the `noise_injector` field of the `ForwardMapWrapper`
+"""
+get_noise_injector(fmw::ForwardMapWrapper) = fmw.noise_injector
 
 
 ### Emulator constructors and methods
@@ -468,6 +479,7 @@ Positional Arguments
 Keyword Arguments 
  -  `encoder_schedule`[=`nothing`]: the schedule of data encoding/decoding. This will be passed into the method `create_encoder_schedule` internally. `nothing` sets sets a default schedule `[(decorrelate_sample_cov(), "in_and_out")]`, or `[(decorrelate_sample_cov(), "in"), (decorrelate_structure_mat(), "out")]` if an `encoder_kwargs` has a key `:obs_noise_cov`. Pass `[]` for no encoding.
  - `encoder_kwargs`[=`NamedTuple()`]: a Dict or NamedTuple with keyword arguments to be passed to `initialize_and_encode_with_schedule!`
+ - `boost_for_loss`[=`0.001`]: A threshold to implementing noise boosting when decoding from an lossily encoded space. If the variance loss due to encoding is `>boost_for_loss` then additional noise is added to the null-space (consistent with the prior correlation structure).
 """
 function forward_map_wrapper(
     forward_map::Function,
@@ -475,6 +487,7 @@ function forward_map_wrapper(
     input_output_pairs::PairedDataContainer{FT};
     encoder_schedule = nothing,
     encoder_kwargs = NamedTuple(),
+    boost_for_loss = 0.001,
 ) where {FT <: Real, PD <: ParameterDistribution}
 
     # Default processing: decorrelate_sample_cov() where no structure matrix provided, and decorrelate_structure_mat() where provided.
@@ -495,12 +508,17 @@ function forward_map_wrapper(
     (encoded_io_pairs, input_structure_mats, output_structure_mats, _, _) =
         initialize_and_encode_with_schedule!(encoder_schedule, input_output_pairs; encoder_kwargs...)
 
+    # As we apply FMW in decoded space, it may be that we need to add additional noise if the encoder is suitably lossy (determined by >`boost_for_loss`). We create a noise injector which puts noise in the null space, retaining correlations from the prior. Precompute it here:
+    noise_injector = make_noise_injector(encoder_schedule, prior, boost_for_loss)
+
+
     return ForwardMapWrapper{FT, typeof(encoder_schedule), typeof(prior)}(
         forward_map,
         prior,
         input_output_pairs,
         encoded_io_pairs,
         encoder_schedule,
+        noise_injector,
     )
 end
 
@@ -555,9 +573,9 @@ function predict(
     end
 
     prior = get_prior(fmw)
-    #need to boost to decode inputs
     if in_already_encoded
-        decoded_inputs = Matrix(decode_data(fmw, new_inputs, "in"))
+        # if suitably lossy encoder, we must also inject noise into its null space
+        decoded_inputs = decode_and_add_noise(get_noise_injector(fmw), new_inputs)
     else
         decoded_inputs = new_inputs
     end

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -318,10 +318,10 @@ Return type of N inputs: (in the output space)
 function predict(
     emulator::Emulator{FT},
     new_inputs::AM;
-    encode=nothing, # maps decoded inputs to decoded outputs
+    encode = nothing, # maps decoded inputs to decoded outputs
     mlt_kwargs...,
 ) where {FT <: AbstractFloat, AM <: AbstractMatrix}
-                    
+
     # Check if the size of new_inputs is consistent with the training data input
     input_dim, output_dim = size(get_io_pairs(emulator), 1)
     encoded_input_dim, encoded_output_dim = size(get_encoded_io_pairs(emulator), 1)
@@ -338,9 +338,9 @@ function predict(
 
     # note the logic below
     in_already_encoded = encode ∈ ["in", "in_and_out"]
-    out_to_be_decoded = encode ∈ ["out","in_and_out"] 
-    
-    
+    out_to_be_decoded = encode ∈ ["out", "in_and_out"]
+
+
     # encode the new input data
     if !in_already_encoded
         encoded_inputs = encode_data(emulator, new_inputs, "in")
@@ -443,8 +443,8 @@ end
 function predict(
     fmw::FMW,
     new_inputs::AM;
-    encode=nothing, # maps decoded inputs to decoded outputs
-    add_obs_noise_cov=false,
+    encode = nothing, # maps decoded inputs to decoded outputs
+    add_obs_noise_cov = false,
 ) where {FMW <: ForwardMapWrapper, AM <: AbstractMatrix}
     # Check if the size of new_inputs is consistent with the training input data
     input_dim, output_dim = size(get_io_pairs(fmw), 1)
@@ -461,7 +461,7 @@ function predict(
     end
 
     in_already_encoded = encode ∈ ["in", "in_and_out"]
-    out_to_be_decoded = encode ∈ ["out","in_and_out"] 
+    out_to_be_decoded = encode ∈ ["out", "in_and_out"]
     #need to boost to decoded inputs
     if in_already_encoded
         # Sample from the null space
@@ -524,12 +524,12 @@ function predict(
     new_inputs::AM;
     transform_to_real = nothing,
     kwargs...,
-) where {AM <: AbstractMatrix,  EorFMW <: Union{Emulator, ForwardMapWrapper}}
-    
+) where {AM <: AbstractMatrix, EorFMW <: Union{Emulator, ForwardMapWrapper}}
+
     if !isnothing(transform_to_real)
         Base.depwarn(
             """`transform_to_real` keyword is deprecated. Please use the `encode` and `add_obs_noise_cov` keywords instead.
-
+            
 Recommended usage for users is now set by default as:
  - `encode=nothing`, `add_obs_noise_cov=false`
 This behaviour takes in non-encoded inputs, and returns non-encoded outputs. It gives only the uncertainty from the Machine Learning Tool (not inflated by observational noise)
@@ -540,7 +540,7 @@ This simulation will continue with the old behavior:
     """,
             :predict,
         )
-        
+
         # modify kwargs
         kw = Dict(kwargs)
         kw[:add_obs_noise_cov] = true
@@ -549,5 +549,7 @@ This simulation will continue with the old behavior:
     end
 
     return predict(em_or_fmw, new_inputs; kwargs...)
+
+end
 
 end

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -503,10 +503,19 @@ function predict(
 
     in_already_encoded = encode ∈ ["in", "in_and_out"]
     out_to_be_decoded = encode ∈ ["out", "in_and_out"]
+    prior = get_prior(fmw)
     #need to boost to decoded inputs
     if in_already_encoded
-        # Sample from the null space
+        # decode 
         decoded_inputs = Matrix(decode_data(fmw, new_inputs, "in"))
+        # add sample from null space:
+        prior_samples = sample(prior, size(decoded_inputs,2))
+        null_samples = prior_samples - Matrix(decode_data(
+            fmw,
+            encode_data(fmw, prior_samples, "in"),
+            "in",
+        ))
+        decoded_inputs .+= null_samples
     else
         decoded_inputs = new_inputs
     end
@@ -514,7 +523,6 @@ function predict(
     # Vector-methods uncertainties=covariances: [enc_out_dim x enc_out_dim x n_samples)
 
     # unlike the emulator, the forward map runs in the physical, decoded space. and must be encoded where necessary 
-    prior = get_prior(fmw)
     forward_map = get_forward_map(fmw)
     fm_unc = x -> forward_map(transform_unconstrained_to_constrained(prior, x))
 

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -318,9 +318,10 @@ Return type of N inputs: (in the output space)
 function predict(
     emulator::Emulator{FT},
     new_inputs::AM;
-    transform_to_real = false,
+    encode=nothing, # maps decoded inputs to decoded outputs
     mlt_kwargs...,
 ) where {FT <: AbstractFloat, AM <: AbstractMatrix}
+                    
     # Check if the size of new_inputs is consistent with the training data input
     input_dim, output_dim = size(get_io_pairs(emulator), 1)
     encoded_input_dim, encoded_output_dim = size(get_encoded_io_pairs(emulator), 1)
@@ -335,8 +336,17 @@ function predict(
         )
     end
 
+    # note the logic below
+    in_already_encoded = encode ∈ ["in", "in_and_out"]
+    out_to_be_decoded = encode ∈ ["out","in_and_out"] 
+    
+    
     # encode the new input data
-    encoded_inputs = encode_data(emulator, new_inputs, "in")
+    if !in_already_encoded
+        encoded_inputs = encode_data(emulator, new_inputs, "in")
+    else
+        encoded_inputs = new_inputs
+    end
     # predict in encoding space
     # returns outputs: [enc_out_dim x n_samples]
     # Scalar-methods uncertainties=variances: [enc_out_dim x n_samples]
@@ -346,7 +356,7 @@ function predict(
     var_or_cov = (ndims(encoded_uncertainties) == 2) ? "var" : "cov"
 
     # return decoded or encoded?
-    if transform_to_real
+    if out_to_be_decoded
         decoded_outputs = decode_data(emulator, encoded_outputs, "out")
 
         decoded_covariances = zeros(eltype(encoded_outputs), output_dim, output_dim, size(encoded_uncertainties)[end])
@@ -433,7 +443,8 @@ end
 function predict(
     fmw::FMW,
     new_inputs::AM;
-    transform_to_real = false,
+    encode=nothing, # maps decoded inputs to decoded outputs
+    add_obs_noise_cov=false,
 ) where {FMW <: ForwardMapWrapper, AM <: AbstractMatrix}
     # Check if the size of new_inputs is consistent with the training input data
     input_dim, output_dim = size(get_io_pairs(fmw), 1)
@@ -449,6 +460,15 @@ function predict(
         )
     end
 
+    in_already_encoded = encode ∈ ["in", "in_and_out"]
+    out_to_be_decoded = encode ∈ ["out","in_and_out"] 
+    #need to boost to decoded inputs
+    if in_already_encoded
+        # Sample from the null space
+        decoded_inputs = ...
+    else
+        decoded_inputs = new_inputs
+    end
     # Scalar-methods uncertainties=variances: [enc_out_dim x n_samples]
     # Vector-methods uncertainties=covariances: [enc_out_dim x enc_out_dim x n_samples)
 
@@ -457,10 +477,10 @@ function predict(
     forward_map = get_forward_map(fmw)
     fm_unc = x -> forward_map(transform_unconstrained_to_constrained(prior, x))
 
-    decoded_outputs = reduce(hcat, map(fm_unc, eachcol(new_inputs))) # apply map and return: [out_dim x n_samples]
+    decoded_outputs = reduce(hcat, map(fm_unc, eachcol(decoded_inputs))) # apply map and return: [out_dim x n_samples]
 
     var_or_cov = (output_dim == 1) ? "var" : "cov"
-    if transform_to_real
+    if out_to_be_decoded
         # uncertainty returned is just `I` in encoded space
         decoded_cov = Matrix(decode_structure_matrix(fmw, I(output_dim), "out"))
 
@@ -495,5 +515,39 @@ function predict(
         end
     end
 end
+
+
+### Deprecated keywords
+
+function predict(
+    em_or_fmw::EorFMW,
+    new_inputs::AM;
+    transform_to_real = nothing,
+    kwargs...,
+) where {AM <: AbstractMatrix,  EorFMW <: Union{Emulator, ForwardMapWrapper}}
+    
+    if !isnothing(transform_to_real)
+        Base.depwarn(
+            """`transform_to_real` keyword is deprecated. Please use the `encode` and `add_obs_noise_cov` keywords instead.
+
+Recommended usage for users is now set by default as:
+ - `encode=nothing`, `add_obs_noise_cov=false`
+This behaviour takes in non-encoded inputs, and returns non-encoded outputs. It gives only the uncertainty from the Machine Learning Tool (not inflated by observational noise)
+
+This simulation will continue with the old behavior:
+ - `transform_to_real=true` replaced with `encode=nothing, add_obs_noise_cov=true`
+ - `transform_to_real=false` replaced with `encode="out", add_obs_noise_cov=true`
+    """,
+            :predict,
+        )
+        
+        # modify kwargs
+        kw = Dict(kwargs)
+        kw[:add_obs_noise_cov] = true
+        kw[:encode] = transform_to_real ? nothing : "out"
+        predict(em_or_fmw, new_inputs; kw...)
+    end
+
+    return predict(em_or_fmw, new_inputs; kwargs...)
 
 end

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -479,7 +479,7 @@ Positional Arguments
 Keyword Arguments 
  -  `encoder_schedule`[=`nothing`]: the schedule of data encoding/decoding. This will be passed into the method `create_encoder_schedule` internally. `nothing` sets sets a default schedule `[(decorrelate_sample_cov(), "in_and_out")]`, or `[(decorrelate_sample_cov(), "in"), (decorrelate_structure_mat(), "out")]` if an `encoder_kwargs` has a key `:obs_noise_cov`. Pass `[]` for no encoding.
  - `encoder_kwargs`[=`NamedTuple()`]: a Dict or NamedTuple with keyword arguments to be passed to `initialize_and_encode_with_schedule!`
- - `boost_for_loss`[=`0.001`]: A threshold to implementing noise boosting when decoding from an lossily encoded space. If the variance loss due to encoding is `>boost_for_loss` then additional noise is added to the null-space (consistent with the prior correlation structure).
+ - `noise_injector_threshold`[=`0.001`]: A threshold to implementing noise boosting when decoding from an lossily encoded space. If the variance loss due to encoding is `>noise_injector_threshold` then additional noise is added to the null-space (consistent with the prior correlation structure).
 """
 function forward_map_wrapper(
     forward_map::Function,
@@ -487,7 +487,8 @@ function forward_map_wrapper(
     input_output_pairs::PairedDataContainer{FT};
     encoder_schedule = nothing,
     encoder_kwargs = NamedTuple(),
-    boost_for_loss = 0.001,
+    noise_injector_threshold = 0.001,
+    noise_injector_scaling = 0.1,
 ) where {FT <: Real, PD <: ParameterDistribution}
 
     # Default processing: decorrelate_sample_cov() where no structure matrix provided, and decorrelate_structure_mat() where provided.
@@ -508,8 +509,8 @@ function forward_map_wrapper(
     (encoded_io_pairs, input_structure_mats, output_structure_mats, _, _) =
         initialize_and_encode_with_schedule!(encoder_schedule, input_output_pairs; encoder_kwargs...)
 
-    # As we apply FMW in decoded space, it may be that we need to add additional noise if the encoder is suitably lossy (determined by >`boost_for_loss`). We create a noise injector which puts noise in the null space, retaining correlations from the prior. Precompute it here:
-    noise_injector = create_noise_injector(encoder_schedule, prior, boost_for_loss)
+    # As we apply FMW in decoded space, it may be that we need to add additional noise if the encoder is suitably lossy (determined by >`noise_injector_threshold`). We create a noise injector which puts noise in the null space, retaining correlations from the prior. Precompute it here:
+    noise_injector = create_noise_injector(encoder_schedule, prior, noise_injector_threshold, noise_injector_scaling)
 
 
     return ForwardMapWrapper{FT, typeof(encoder_schedule), typeof(prior), typeof(noise_injector)}(

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -242,6 +242,22 @@ $(TYPEDSIGNATURES)
 Encode the new data (a `DataContainer`, or matrix where data are columns) representing inputs (`"in"`) or outputs (`"out"`). with the stored and initialized encoder schedule.
 """
 function encode_data(
+    encoder_schedule::VV,
+    data::MorDC,
+    in_or_out::AS,
+) where {
+    AS <: AbstractString,
+    MorDC <: Union{AbstractMatrix, DataContainer},
+    VV <: AbstractVector,
+}
+    if isa(data, AbstractMatrix)
+        return get_data(encode_with_schedule(encoder_schedule, DataContainer(data), in_or_out))
+    else
+        return encode_with_schedule(encoder_schedule, data, in_or_out)
+    end
+end
+
+function encode_data(
     em_or_fmw::EorFMW,
     data::MorDC,
     in_or_out::AS,
@@ -250,12 +266,9 @@ function encode_data(
     MorDC <: Union{AbstractMatrix, DataContainer},
     EorFMW <: Union{Emulator, ForwardMapWrapper},
 }
-    if isa(data, AbstractMatrix)
-        return get_data(encode_with_schedule(get_encoder_schedule(em_or_fmw), DataContainer(data), in_or_out))
-    else
-        return encode_with_schedule(get_encoder_schedule(em_or_fmw), data, in_or_out)
-    end
+    return encode_data(get_encoder_schedule(em_or_fmw), data, in_or_out)
 end
+    
 
 """
 $(TYPEDSIGNATURES)
@@ -263,11 +276,19 @@ $(TYPEDSIGNATURES)
 Encode a new structure matrix in the input space (`"in"`) or output space (`"out"`). with the stored and initialized encoder schedule. 
 """
 function encode_structure_matrix(
+    encoder_schedule::VV,
+    structure_mat,
+    in_or_out::AS,
+) where {AS <: AbstractString, VV <: AbstractVector}
+    return encode_with_schedule(encoder_schedule, structure_mat, in_or_out)
+end
+
+function encode_structure_matrix(
     em_or_fmw::EorFMW,
     structure_mat,
     in_or_out::AS,
 ) where {AS <: AbstractString, EorFMW <: Union{Emulator, ForwardMapWrapper}}
-    return encode_with_schedule(get_encoder_schedule(em_or_fmw), structure_mat, in_or_out)
+    return encode_structure_matrix(get_encoder_schedule(em_or_fmw), structure_mat, in_or_out)
 end
 
 
@@ -277,6 +298,22 @@ $(TYPEDSIGNATURES)
 Decode the new data (a `DataContainer`, or matrix where data are columns) representing inputs (`"in"`) or outputs (`"out"`). with the stored and initialized encoder schedule.
 """
 function decode_data(
+    encoder_schedule::VV,
+    data::MorDC,
+    in_or_out::AS,
+) where {
+    AS <: AbstractString,
+    MorDC <: Union{AbstractMatrix, DataContainer},
+    VV <: AbstractVector,
+}
+    if isa(data, AbstractMatrix)
+        return get_data(decode_with_schedule(encoder_schedule, DataContainer(data), in_or_out))
+    else
+        return decode_with_schedule(encoder_schedule, data, in_or_out)
+    end
+end
+
+function decode_data(
     em_or_fmw::EorFMW,
     data::MorDC,
     in_or_out::AS,
@@ -285,11 +322,7 @@ function decode_data(
     MorDC <: Union{AbstractMatrix, DataContainer},
     EorFMW <: Union{Emulator, ForwardMapWrapper},
 }
-    if isa(data, AbstractMatrix)
-        return get_data(decode_with_schedule(get_encoder_schedule(em_or_fmw), DataContainer(data), in_or_out))
-    else
-        return decode_with_schedule(get_encoder_schedule(em_or_fmw), data, in_or_out)
-    end
+    return decode_data(get_encoder_schedule(em_or_fmw), data, in_or_out)
 end
 
 """
@@ -298,13 +331,21 @@ $(TYPEDSIGNATURES)
 Decode a new structure matrix in the input space (`"in"`) or output space (`"out"`). with the stored and initialized encoder schedule. 
 """
 function decode_structure_matrix(
+    encoder_schedule::VV,
+    structure_mat,
+    in_or_out::AS,
+) where {AS <: AbstractString, VV <: AbstractVector}
+    return decode_with_schedule(encoder_schedule, structure_mat, in_or_out)
+end
+
+function decode_structure_matrix(
     em_or_fmw::EorFMW,
     structure_mat,
     in_or_out::AS,
 ) where {AS <: AbstractString, EorFMW <: Union{Emulator, ForwardMapWrapper}}
-    return decode_with_schedule(get_encoder_schedule(em_or_fmw), structure_mat, in_or_out)
+    return decode_structure_matrix(get_encoder_schedule(em_or_fmw), structure_mat, in_or_out)
 end
-
+    
 """
 $(TYPEDSIGNATURES)
 
@@ -465,7 +506,7 @@ function predict(
     #need to boost to decoded inputs
     if in_already_encoded
         # Sample from the null space
-        decoded_inputs = ...
+        decoded_inputs = Matrix(decode_data(fmw, new_inputs, "in"))
     else
         decoded_inputs = new_inputs
     end

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -496,14 +496,9 @@ function predict(
     in_already_encoded = encode ∈ ["in", "in_and_out"]
     out_to_be_decoded = encode ∈ ["out", "in_and_out"]
     prior = get_prior(fmw)
-    #need to boost to decoded inputs
+    #need to boost to decode inputs
     if in_already_encoded
-        # decode 
         decoded_inputs = Matrix(decode_data(fmw, new_inputs, "in"))
-        # add sample from null space:
-        prior_samples = sample(prior, size(decoded_inputs, 2))
-        null_samples = prior_samples - Matrix(decode_data(fmw, encode_data(fmw, prior_samples, "in"), "in"))
-        decoded_inputs .+= null_samples
     else
         decoded_inputs = new_inputs
     end

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -378,7 +378,7 @@ function predict(
         )
     end
 
-    
+
     # encode the new input data
     if !in_already_encoded
         encoded_inputs = encode_data(emulator, new_inputs, "in")
@@ -389,7 +389,12 @@ function predict(
     # returns outputs: [enc_out_dim x n_samples]
     # Scalar-methods uncertainties=variances: [enc_out_dim x n_samples]
     # Vector-methods uncertainties=covariances: [enc_out_dim x enc_out_dim x n_samples)
-    encoded_outputs, encoded_uncertainties = predict(get_machine_learning_tool(emulator), encoded_inputs; add_obs_noise_cov=add_obs_noise_cov, mlt_kwargs...)
+    encoded_outputs, encoded_uncertainties = predict(
+        get_machine_learning_tool(emulator),
+        encoded_inputs;
+        add_obs_noise_cov = add_obs_noise_cov,
+        mlt_kwargs...,
+    )
 
     var_or_cov = (ndims(encoded_uncertainties) == 2) ? "var" : "cov"
 
@@ -483,7 +488,7 @@ function predict(
     new_inputs::AM;
     encode = nothing, # maps decoded inputs to decoded outputs
     add_obs_noise_cov = false,
-    transform_to_real=nothing
+    transform_to_real = nothing,
 ) where {FMW <: ForwardMapWrapper, AM <: AbstractMatrix}
 
     encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
@@ -574,8 +579,10 @@ This behaviour takes in non-encoded inputs, and returns non-encoded outputs. It 
 This simulation will continue with the old behavior:
  - `transform_to_real=true` replaced with `encode=nothing, add_obs_noise_cov=true`
  - `transform_to_real=false` replaced with `encode="out", add_obs_noise_cov=true`
-    """, maxlog=1)
-        
+    """,
+            maxlog = 1
+        )
+
         # modify kwargs
         add_onc = true
         enc = transform_to_real ? nothing : "out"
@@ -584,7 +591,7 @@ This simulation will continue with the old behavior:
         return encode, add_obs_noise_cov
     end
 end
-    
+
 
 
 end

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -352,8 +352,12 @@ function predict(
     emulator::Emulator{FT},
     new_inputs::AM;
     encode = nothing, # maps decoded inputs to decoded outputs
+    add_obs_noise_cov = false,
+    transform_to_real = nothing,
     mlt_kwargs...,
 ) where {FT <: AbstractFloat, AM <: AbstractMatrix}
+
+    encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
 
     # Check if the size of new_inputs is consistent with the training data input
     input_dim, output_dim = size(get_io_pairs(emulator), 1)
@@ -371,8 +375,7 @@ function predict(
 
     # note the logic below
     in_already_encoded = encode ∈ ["in", "in_and_out"]
-    out_to_be_decoded = encode ∈ ["out", "in_and_out"]
-
+    out_to_be_decoded = encode ∉ ["out", "in_and_out"]
 
     # encode the new input data
     if !in_already_encoded
@@ -384,7 +387,7 @@ function predict(
     # returns outputs: [enc_out_dim x n_samples]
     # Scalar-methods uncertainties=variances: [enc_out_dim x n_samples]
     # Vector-methods uncertainties=covariances: [enc_out_dim x enc_out_dim x n_samples)
-    encoded_outputs, encoded_uncertainties = predict(get_machine_learning_tool(emulator), encoded_inputs; mlt_kwargs...)
+    encoded_outputs, encoded_uncertainties = predict(get_machine_learning_tool(emulator), encoded_inputs; add_obs_noise_cov=add_obs_noise_cov, mlt_kwargs...)
 
     var_or_cov = (ndims(encoded_uncertainties) == 2) ? "var" : "cov"
 
@@ -478,7 +481,11 @@ function predict(
     new_inputs::AM;
     encode = nothing, # maps decoded inputs to decoded outputs
     add_obs_noise_cov = false,
+    transform_to_real=nothing
 ) where {FMW <: ForwardMapWrapper, AM <: AbstractMatrix}
+
+    encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
+
     # Check if the size of new_inputs is consistent with the training input data
     input_dim, output_dim = size(get_io_pairs(fmw), 1)
     encoded_input_dim, encoded_output_dim = size(get_encoded_io_pairs(fmw), 1)
@@ -494,7 +501,8 @@ function predict(
     end
 
     in_already_encoded = encode ∈ ["in", "in_and_out"]
-    out_to_be_decoded = encode ∈ ["out", "in_and_out"]
+    out_to_be_decoded = encode ∉ ["out", "in_and_out"]
+
     prior = get_prior(fmw)
     #need to boost to decode inputs
     if in_already_encoded
@@ -550,38 +558,31 @@ end
 
 
 ### Deprecated keywords
-
-function predict(
-    em_or_fmw::EorFMW,
-    new_inputs::AM;
-    transform_to_real = nothing,
-    kwargs...,
-) where {AM <: AbstractMatrix, EorFMW <: Union{Emulator, ForwardMapWrapper}}
-
+function deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
     if !isnothing(transform_to_real)
         Base.depwarn(
             """`transform_to_real` keyword is deprecated. Please use the `encode` and `add_obs_noise_cov` keywords instead.
-            
+                                             
 Recommended usage for users is now set by default as:
  - `encode=nothing`, `add_obs_noise_cov=false`
 This behaviour takes in non-encoded inputs, and returns non-encoded outputs. It gives only the uncertainty from the Machine Learning Tool (not inflated by observational noise)
-
+               
 This simulation will continue with the old behavior:
  - `transform_to_real=true` replaced with `encode=nothing, add_obs_noise_cov=true`
  - `transform_to_real=false` replaced with `encode="out", add_obs_noise_cov=true`
     """,
-            :predict,
+            :deprecate_transform_to_real
         )
-
+        
         # modify kwargs
-        kw = Dict(kwargs)
-        kw[:add_obs_noise_cov] = true
-        kw[:encode] = transform_to_real ? nothing : "out"
-        predict(em_or_fmw, new_inputs; kw...)
+        add_onc = true
+        enc = transform_to_real ? nothing : "out"
+        return enc, add_onc
+    else
+        return encode, add_obs_noise_cov
     end
-
-    return predict(em_or_fmw, new_inputs; kwargs...)
-
 end
+    
+
 
 end

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -560,7 +560,7 @@ end
 ### Deprecated keywords
 function deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
     if !isnothing(transform_to_real)
-        Base.depwarn(
+        @warn(
             """`transform_to_real` keyword is deprecated. Please use the `encode` and `add_obs_noise_cov` keywords instead.
                                              
 Recommended usage for users is now set by default as:
@@ -570,9 +570,7 @@ This behaviour takes in non-encoded inputs, and returns non-encoded outputs. It 
 This simulation will continue with the old behavior:
  - `transform_to_real=true` replaced with `encode=nothing, add_obs_noise_cov=true`
  - `transform_to_real=false` replaced with `encode="out", add_obs_noise_cov=true`
-    """,
-            :deprecate_transform_to_real
-        )
+    """, maxlog=1)
         
         # modify kwargs
         add_onc = true

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -342,7 +342,17 @@ end
 $(TYPEDSIGNATURES)
 
 Makes a prediction using the emulator on new inputs (each new inputs given as data columns).
-Default is to predict in the decorrelated space.
+
+Keyword args
+- `encode` [=`nothing`]: For the input encoder `Eᵢ`, and output decoder `Dₒ` stored in the emulator, we have learnt a predict method method `G` in the encoded space. Interpret the keyword as follows:
+    - nothing     : applies Dₒ∘G∘Eᵢ(x) (nothing is encoded) - most common for user interaction
+    - "in"        : applies Dₒ∘G(z) (the inputs are provided as encoded (z=Eᵢx))
+    - "out"       : applies G∘Eᵢ(x) (the outputs are returned as encoded)
+    - "in_and_out": applies G(z) (inputs (z=Eᵢx) and outputs are both encoded) - internally called by `Sample` method
+- `add_obs_noise_cov`[=`false`]: When returning the prediction covariance, whether to add the observational noise
+    - `false`: Only return the uncertainty given by the machine learning tool - most common for user emulator validation
+    - `true` : Return the sum of emulator and observational uncertainty - internally called by `Sample` method
+- All other kwargs are passed into the machine learning tool.
 
 Return type of N inputs: (in the output space)
   - 1-D: mean [1 x N], cov [1 x N]
@@ -445,7 +455,20 @@ function predict(
 end
 
 ### Forward Map constructor and methods
+"""
+$(TYPEDSIGNATURES)
 
+Constructor of the `ForwardMapWrapper` object. Behaves similarly to constructing the `Emulator` but additionally requires the `prior` parameter distribution.
+
+Positional Arguments
+ - `forward_map`: a function that represents the forward map `F(x)` mapping physical parameters (in constrained space) to outputs
+ - `prior`: a `ParameterDistribution` object describing the prior on the physical parameters.
+ - `input_output_pairs`: the paired input-output data points stored in a `PairedDataContainer`
+
+Keyword Arguments 
+ -  `encoder_schedule`[=`nothing`]: the schedule of data encoding/decoding. This will be passed into the method `create_encoder_schedule` internally. `nothing` sets sets a default schedule `[(decorrelate_sample_cov(), "in_and_out")]`, or `[(decorrelate_sample_cov(), "in"), (decorrelate_structure_mat(), "out")]` if an `encoder_kwargs` has a key `:obs_noise_cov`. Pass `[]` for no encoding.
+ - `encoder_kwargs`[=`NamedTuple()`]: a Dict or NamedTuple with keyword arguments to be passed to `initialize_and_encode_with_schedule!`
+"""
 function forward_map_wrapper(
     forward_map::Function,
     prior::PD,
@@ -482,7 +505,26 @@ function forward_map_wrapper(
 end
 
 
+"""
+$(TYPEDSIGNATURES)
 
+Makes a prediction using the ForwardMapWrapper on new inputs (each new inputs given as data columns).
+
+Keyword args
+- `encode` [=`nothing`]: For the output encoder `Eₒ`, and input decoder `Dᵢ` stored in the `ForwardMapWrapper`, we have provided the forward map `G` in the decoded space. Interpret the keyword as follows:
+    - nothing     : applies G(x) (nothing is encoded) - most common for user interaction
+    - "in"        : applies G∘Dᵢ(z) (the inputs are provided as encoded (x=Dᵢz))
+    - "out"       : applies Eₒ∘G(x) (the outputs are returned as encoded)
+    - "in_and_out": applies Eₒ∘G∘Dᵢ(z) (inputs (x=Dᵢz) and outputs are both encoded) - internally called by `Sample` method
+- `add_obs_noise_cov`[=`false`]: When returning the prediction covariance, whether to add the observational noise
+    - `false`: Only return the uncertainty given by the machine learning tool - most common for user emulator validation
+    - `true` : Return the sum of emulator and observational uncertainty - internally called by `Sample` method
+- All other kwargs are passed into the machine learning tool.
+
+Return type of N inputs: (in the output space)
+  - 1-D: mean [1 x N], cov [1 x N]
+  - p-D: mean [p x N], cov N x [p x p] 
+"""
 function predict(
     fmw::FMW,
     new_inputs::AM;

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -509,10 +509,10 @@ function forward_map_wrapper(
         initialize_and_encode_with_schedule!(encoder_schedule, input_output_pairs; encoder_kwargs...)
 
     # As we apply FMW in decoded space, it may be that we need to add additional noise if the encoder is suitably lossy (determined by >`boost_for_loss`). We create a noise injector which puts noise in the null space, retaining correlations from the prior. Precompute it here:
-    noise_injector = make_noise_injector(encoder_schedule, prior, boost_for_loss)
+    noise_injector = create_noise_injector(encoder_schedule, prior, boost_for_loss)
 
 
-    return ForwardMapWrapper{FT, typeof(encoder_schedule), typeof(prior)}(
+    return ForwardMapWrapper{FT, typeof(encoder_schedule), typeof(prior), typeof(noise_injector)}(
         forward_map,
         prior,
         input_output_pairs,

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -359,23 +359,25 @@ function predict(
 
     encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
 
+    # For the logic below
+    in_already_encoded = encode ∈ ["in", "in_and_out"]
+    out_to_be_decoded = encode ∉ ["out", "in_and_out"]
+
     # Check if the size of new_inputs is consistent with the training data input
     input_dim, output_dim = size(get_io_pairs(emulator), 1)
     encoded_input_dim, encoded_output_dim = size(get_encoded_io_pairs(emulator), 1)
 
+    check_dim = in_already_encoded ? encoded_input_dim : input_dim
     N_samples = size(new_inputs, 2)
 
-    if size(new_inputs, 1) != input_dim
+    if size(new_inputs, 1) != check_dim
         throw(
             ArgumentError(
-                "Emulator object `io_pairs` and new inputs do not have consistent dimensions, expected $(input_dim), received $(size(new_inputs,1))",
+                "Emulator object `io_pairs` (resp. `encoded_io_pairs`) and new inputs do not have consistent dimensions, expected $(check_dim), received $(size(new_inputs,1))",
             ),
         )
     end
 
-    # note the logic below
-    in_already_encoded = encode ∈ ["in", "in_and_out"]
-    out_to_be_decoded = encode ∉ ["out", "in_and_out"]
     
     # encode the new input data
     if !in_already_encoded
@@ -486,22 +488,24 @@ function predict(
 
     encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
 
-    # Check if the size of new_inputs is consistent with the training input data
+    # For the logic below
+    in_already_encoded = encode ∈ ["in", "in_and_out"]
+    out_to_be_decoded = encode ∉ ["out", "in_and_out"]
+
+    # Check if the size of new_inputs is consistent with the training data input
     input_dim, output_dim = size(get_io_pairs(fmw), 1)
     encoded_input_dim, encoded_output_dim = size(get_encoded_io_pairs(fmw), 1)
 
+    check_dim = in_already_encoded ? encoded_input_dim : input_dim
     N_samples = size(new_inputs, 2)
 
-    if size(new_inputs, 1) != input_dim
+    if size(new_inputs, 1) != check_dim
         throw(
             ArgumentError(
-                "ForwardMapObject `io_pairs` and new inputs do not have consistent dimensions, expected $(input_dim), received $(size(new_inputs,1))",
+                "ForwardMapWrapper object `io_pairs` (resp. `encoded_io_pairs`) and new inputs do not have consistent dimensions, expected $(check_dim), received $(size(new_inputs,1))",
             ),
         )
     end
-
-    in_already_encoded = encode ∈ ["in", "in_and_out"]
-    out_to_be_decoded = encode ∉ ["out", "in_and_out"]
 
     prior = get_prior(fmw)
     #need to boost to decode inputs

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -33,8 +33,8 @@ abstract type MachineLearningTool end
 
 # include the different <: ML models
 
-include(joinpath("MachineLearningTools","GaussianProcess.jl")) #for GaussianProcess
-include(joinpath("MachineLearningTools","RandomFeature.jl")) # Random Freatures
+include(joinpath("MachineLearningTools", "GaussianProcess.jl")) #for GaussianProcess
+include(joinpath("MachineLearningTools", "RandomFeature.jl")) # Random Freatures
 # include(joinpath("MachineLearningTools","NeuralNetwork.jl"))
 # etc.
 
@@ -116,7 +116,7 @@ $(TYPEDFIELDS)
 # Constructors:
 - `forward_map_wrapper(forward_map, prior, input_output_pairs; encoder_schedule=nothing, encoder_kwargs=NamedTuple())`
 """
-struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution} 
+struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution}
     "function that represents the forward map"
     forward_map::Function
     "a parameter distribution, containing transformations to constrain the forward map inputs"
@@ -388,7 +388,7 @@ function predict(
             return encoded_outputs, encoded_covariances_mat[1, :, :]
         end
     end
-    
+
 end
 
 ### Forward Map constructor and methods
@@ -455,20 +455,20 @@ function predict(
     # unlike the emulator, the forward map runs in the physical, decoded space. and must be encoded where necessary 
     prior = get_prior(fmw)
     forward_map = get_forward_map(fmw)
-    fm_unc= x-> forward_map(transform_unconstrained_to_constrained(prior, x)) 
+    fm_unc = x -> forward_map(transform_unconstrained_to_constrained(prior, x))
 
     decoded_outputs = reduce(hcat, map(fm_unc, eachcol(new_inputs))) # apply map and return: [out_dim x n_samples]
-    
+
     var_or_cov = (output_dim == 1) ? "var" : "cov"
     if transform_to_real
         # uncertainty returned is just `I` in encoded space
         decoded_cov = Matrix(decode_structure_matrix(fmw, I(output_dim), "out"))
-        
-        decoded_covariances = zeros(eltype(decoded_outputs), output_dim, output_dim, size(decoded_outputs,2))
-        for i in 1:size(decoded_covariances,3)
+
+        decoded_covariances = zeros(eltype(decoded_outputs), output_dim, output_dim, size(decoded_outputs, 2))
+        for i in 1:size(decoded_covariances, 3)
             decoded_covariances[:, :, i] .= decoded_cov
         end
-        
+
         if output_dim > 1
             return decoded_outputs, eachslice(decoded_covariances, dims = 3)
         else
@@ -477,16 +477,16 @@ function predict(
         end
 
     else # We encode
-        encoded_outputs = Matrix(encode_data(fmw, decoded_outputs ,"out"))
-        encoded_output_dim = size(encoded_outputs,1)
+        encoded_outputs = Matrix(encode_data(fmw, decoded_outputs, "out"))
+        encoded_output_dim = size(encoded_outputs, 1)
         encoded_cov = I(encoded_output_dim)
 
         encoded_covariances_mat =
-            zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_outputs,2))
-        for i in 1:size(encoded_covariances_mat,3)
+            zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_outputs, 2))
+        for i in 1:size(encoded_covariances_mat, 3)
             encoded_covariances_mat[:, :, i] = encoded_cov
         end
-        
+
         if encoded_output_dim > 1
             return encoded_outputs, eachslice(encoded_covariances_mat, dims = 3)
         else
@@ -496,4 +496,4 @@ function predict(
     end
 end
 
-end 
+end

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -479,7 +479,8 @@ Positional Arguments
 Keyword Arguments 
  -  `encoder_schedule`[=`nothing`]: the schedule of data encoding/decoding. This will be passed into the method `create_encoder_schedule` internally. `nothing` sets sets a default schedule `[(decorrelate_sample_cov(), "in_and_out")]`, or `[(decorrelate_sample_cov(), "in"), (decorrelate_structure_mat(), "out")]` if an `encoder_kwargs` has a key `:obs_noise_cov`. Pass `[]` for no encoding.
  - `encoder_kwargs`[=`NamedTuple()`]: a Dict or NamedTuple with keyword arguments to be passed to `initialize_and_encode_with_schedule!`
- - `noise_injector_threshold`[=`0.001`]: A threshold to implementing noise boosting when decoding from an lossily encoded space. If the variance loss due to encoding is `>noise_injector_threshold` then additional noise is added to the null-space (consistent with the prior correlation structure).
+ - `noise_injector_threshold`[=`0.001`]: A threshold to implementing noise injection when decoding from an lossily encoded space. If the variance loss due to encoding is `>noise_injector_threshold` then additional noise is added to the null-space (consistent with the prior correlation structure).
+ - `noise_injector_scaling`[=`1.0`]: a multiplicative scaling that is applied to injected noise samples. (1.0 is "consistent" with Gaussian theory, but may cause instability in Non-Gaussian problems and can be reduced)
 """
 function forward_map_wrapper(
     forward_map::Function,
@@ -488,7 +489,7 @@ function forward_map_wrapper(
     encoder_schedule = nothing,
     encoder_kwargs = NamedTuple(),
     noise_injector_threshold = 0.001,
-    noise_injector_scaling = 0.1,
+    noise_injector_scaling = 1.0,
 ) where {FT <: Real, PD <: ParameterDistribution}
 
     # Default processing: decorrelate_sample_cov() where no structure matrix provided, and decorrelate_structure_mat() where provided.

--- a/src/MachineLearningTools/GaussianProcess.jl
+++ b/src/MachineLearningTools/GaussianProcess.jl
@@ -78,7 +78,7 @@ struct GaussianProcess{GPPackage, FT, VV <: AbstractVector} <: MachineLearningTo
     noise_learn::Bool
     "Additional observational or regularization noise in used in GP algorithms"
     alg_reg_noise::FT
-    "Prediction type (`y` to predict the data, `f` to predict the latent function)."
+    "[Deprecated - use `add_obs_noise_cov` kwarg when calling `predict(`] Prediction type (`y` to predict the data, `f` to predict the latent function)."
     prediction_type::PredictionType
     "Regularization vector for each output dimension (based on alg_reg_noise"
     regularization::VV
@@ -260,7 +260,7 @@ end
 function _predict(
     gp::GaussianProcess,
     new_inputs::AbstractMatrix{FT},
-    predict_method::Function,
+    predict_method::Function;
 ) where {FT <: AbstractFloat}
     M = length(gp.models)
     N_samples = size(new_inputs, 2)
@@ -284,11 +284,12 @@ predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}, ::FType) wher
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
-Predict means and covariances in decorrelated output space using Gaussian process models.
+Predict means and covariances in decorrelated output space using Gaussian process models. The use of stored `FType` and `YType` to control this method is deprecated, the return covariance is now determined by the `predict(` kwarg `add_obs_noise_cov` 
 """
-predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}) where {FT <: AbstractFloat} =
-    predict(gp, new_inputs, gp.prediction_type)
-
+function predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}; add_obs_noise_cov=false, mlt_kwargs...) where {FT <: AbstractFloat}
+    pred_type= add_obs_noise_cov ? YType() : FType()
+    return predict(gp, new_inputs, pred_type)
+end    
 
 #now we build the SKLJL implementation
 function build_models!(
@@ -371,13 +372,15 @@ function _SKJL_predict_function(gp_model::PyObject, new_inputs::AbstractMatrix{F
     μ, σ = gp_model.predict(new_inputs', return_std = true)
     return μ, (σ .* σ)
 end
-function predict(gp::GaussianProcess{SKLJL}, new_inputs::AbstractMatrix{FT}) where {FT <: AbstractFloat}
+function predict(gp::GaussianProcess{SKLJL}, new_inputs::AbstractMatrix{FT}; add_obs_noise_cov=false, mlt_kwargs...) where {FT <: AbstractFloat}
     μ, σ2 = _predict(gp, new_inputs, _SKJL_predict_function)
 
     # for SKLJL does not return the observational noise (even if return_std = true)
     # we must add contribution depending on whether we learnt the noise or not.
-    for i in 1:size(σ2, 2)
-        σ2[:, i] = σ2[:, i] + gp.regularization
+    if add_obs_noise_cov
+        for i in 1:size(σ2, 2)
+            σ2[:, i] = σ2[:, i] + gp.regularization
+        end
     end
 
     return μ, σ2
@@ -484,7 +487,7 @@ function optimize_hyperparameters!(gp::GaussianProcess{AGPJL}, args...; kwargs..
     @info "AbstractGP already built. Continuing..."
 end
 
-function predict(gp::GaussianProcess{AGPJL}, new_inputs::AM) where {AM <: AbstractMatrix}
+function predict(gp::GaussianProcess{AGPJL}, new_inputs::AM; add_obs_noise_cov=false, mlt_kwargs...) where {AM <: AbstractMatrix}
 
     N_models = length(gp.models)
     N_samples = size(new_inputs, 2)
@@ -497,8 +500,10 @@ function predict(gp::GaussianProcess{AGPJL}, new_inputs::AM) where {AM <: Abstra
         μ[i, :] = mean(pred)
         σ2[i, :] = var(pred)
     end
-    for i in 1:size(σ2, 2)
-        σ2[:, i] .= σ2[:, i] + gp.regularization
+    if add_obs_noise_cov
+        for i in 1:size(σ2, 2)
+            σ2[:, i] .= σ2[:, i] + gp.regularization
+        end
     end
     return μ, σ2
 end

--- a/src/MachineLearningTools/GaussianProcess.jl
+++ b/src/MachineLearningTools/GaussianProcess.jl
@@ -286,10 +286,15 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 
 Predict means and covariances in decorrelated output space using Gaussian process models. The use of stored `FType` and `YType` to control this method is deprecated, the return covariance is now determined by the `predict(` kwarg `add_obs_noise_cov` 
 """
-function predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}; add_obs_noise_cov=false, mlt_kwargs...) where {FT <: AbstractFloat}
-    pred_type= add_obs_noise_cov ? YType() : FType()
+function predict(
+    gp::GaussianProcess{GPJL},
+    new_inputs::AbstractMatrix{FT};
+    add_obs_noise_cov = false,
+    mlt_kwargs...,
+) where {FT <: AbstractFloat}
+    pred_type = add_obs_noise_cov ? YType() : FType()
     return predict(gp, new_inputs, pred_type)
-end    
+end
 
 #now we build the SKLJL implementation
 function build_models!(
@@ -372,7 +377,12 @@ function _SKJL_predict_function(gp_model::PyObject, new_inputs::AbstractMatrix{F
     μ, σ = gp_model.predict(new_inputs', return_std = true)
     return μ, (σ .* σ)
 end
-function predict(gp::GaussianProcess{SKLJL}, new_inputs::AbstractMatrix{FT}; add_obs_noise_cov=false, mlt_kwargs...) where {FT <: AbstractFloat}
+function predict(
+    gp::GaussianProcess{SKLJL},
+    new_inputs::AbstractMatrix{FT};
+    add_obs_noise_cov = false,
+    mlt_kwargs...,
+) where {FT <: AbstractFloat}
     μ, σ2 = _predict(gp, new_inputs, _SKJL_predict_function)
 
     # for SKLJL does not return the observational noise (even if return_std = true)
@@ -487,7 +497,12 @@ function optimize_hyperparameters!(gp::GaussianProcess{AGPJL}, args...; kwargs..
     @info "AbstractGP already built. Continuing..."
 end
 
-function predict(gp::GaussianProcess{AGPJL}, new_inputs::AM; add_obs_noise_cov=false, mlt_kwargs...) where {AM <: AbstractMatrix}
+function predict(
+    gp::GaussianProcess{AGPJL},
+    new_inputs::AM;
+    add_obs_noise_cov = false,
+    mlt_kwargs...,
+) where {AM <: AbstractMatrix}
 
     N_models = length(gp.models)
     N_samples = size(new_inputs, 2)

--- a/src/MachineLearningTools/ScalarRandomFeature.jl
+++ b/src/MachineLearningTools/ScalarRandomFeature.jl
@@ -631,6 +631,8 @@ function predict(
     srfi::ScalarRandomFeatureInterface,
     new_inputs::MM;
     multithread = "ensemble",
+    add_obs_noise_cov=false,
+    mlt_kwargs...,
 ) where {MM <: AbstractMatrix}
     M = length(get_rfms(srfi))
     N_samples = size(new_inputs, 2)
@@ -653,11 +655,13 @@ function predict(
     end
 
     # add the noise contribution stored within the regularization
-    reg = get_regularization(srfi)[1]
-    reg_diag = isa(reg, UniformScaling) ? reg.λ * ones(M) : diag(reg)
+    if add_obs_noise_cov
+        reg = get_regularization(srfi)[1]
+        reg_diag = isa(reg, UniformScaling) ? reg.λ * ones(M) : diag(reg)
 
-    for i in 1:M
-        σ2[i, :] .+= reg_diag[i]
+        for i in 1:M
+            σ2[i, :] .+= reg_diag[i]
+        end
     end
 
     return μ, σ2

--- a/src/MachineLearningTools/ScalarRandomFeature.jl
+++ b/src/MachineLearningTools/ScalarRandomFeature.jl
@@ -631,7 +631,7 @@ function predict(
     srfi::ScalarRandomFeatureInterface,
     new_inputs::MM;
     multithread = "ensemble",
-    add_obs_noise_cov=false,
+    add_obs_noise_cov = false,
     mlt_kwargs...,
 ) where {MM <: AbstractMatrix}
     M = length(get_rfms(srfi))

--- a/src/MachineLearningTools/VectorRandomFeature.jl
+++ b/src/MachineLearningTools/VectorRandomFeature.jl
@@ -656,7 +656,12 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 
 Prediction of data observation (not latent function) at new inputs (passed in as columns in a matrix). That is, we add the observational noise into predictions.
 """
-function predict(vrfi::VectorRandomFeatureInterface, new_inputs::M; add_obs_noise_cov=false, mlt_kwargs...) where {M <: AbstractMatrix}
+function predict(
+    vrfi::VectorRandomFeatureInterface,
+    new_inputs::M;
+    add_obs_noise_cov = false,
+    mlt_kwargs...,
+) where {M <: AbstractMatrix}
     input_dim = get_input_dim(vrfi)
     output_dim = get_output_dim(vrfi)
     rfm = get_rfms(vrfi)[1]
@@ -680,7 +685,7 @@ function predict(vrfi::VectorRandomFeatureInterface, new_inputs::M; add_obs_nois
         lambda = get_regularization(vrfi)[1]
         for i in 1:N_samples
             σ2[:, :, i] = 0.5 * (σ2[:, :, i] + permutedims(σ2[:, :, i], (2, 1))) + lambda
-            
+
             if !isposdef(σ2[:, :, i])
                 σ2[:, :, i] = posdef_correct(σ2[:, :, i])
             end

--- a/src/MachineLearningTools/VectorRandomFeature.jl
+++ b/src/MachineLearningTools/VectorRandomFeature.jl
@@ -656,7 +656,7 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 
 Prediction of data observation (not latent function) at new inputs (passed in as columns in a matrix). That is, we add the observational noise into predictions.
 """
-function predict(vrfi::VectorRandomFeatureInterface, new_inputs::M) where {M <: AbstractMatrix}
+function predict(vrfi::VectorRandomFeatureInterface, new_inputs::M; add_obs_noise_cov=false, mlt_kwargs...) where {M <: AbstractMatrix}
     input_dim = get_input_dim(vrfi)
     output_dim = get_output_dim(vrfi)
     rfm = get_rfms(vrfi)[1]
@@ -676,12 +676,14 @@ function predict(vrfi::VectorRandomFeatureInterface, new_inputs::M) where {M <: 
     # sizes (output_dim x n_test), (output_dim x output_dim x n_test) 
     # add the noise contribution from the regularization
     # note this is because we are predicting the data here, not the latent function.
-    lambda = get_regularization(vrfi)[1]
-    for i in 1:N_samples
-        σ2[:, :, i] = 0.5 * (σ2[:, :, i] + permutedims(σ2[:, :, i], (2, 1))) + lambda
-
-        if !isposdef(σ2[:, :, i])
-            σ2[:, :, i] = posdef_correct(σ2[:, :, i])
+    if add_obs_noise_cov
+        lambda = get_regularization(vrfi)[1]
+        for i in 1:N_samples
+            σ2[:, :, i] = 0.5 * (σ2[:, :, i] + permutedims(σ2[:, :, i], (2, 1))) + lambda
+            
+            if !isposdef(σ2[:, :, i])
+                σ2[:, :, i] = posdef_correct(σ2[:, :, i])
+            end
         end
     end
     return μ, σ2

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -255,7 +255,7 @@ function emulator_log_density_model(
 
     # predict is written to apply to columns.
     # Returned g is a length-1, Vector{Real} or Vector{Vector}, and g_cov is length-1 Vector{Vector} or Vector{Matrix} respectively
-    g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), transform_to_real = false)
+    g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode="out", add_obs_noise_cov=true)
 
     if isa(g_cov[1], Real)
         return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(prior, θ)
@@ -577,8 +577,10 @@ function MCMCWrapper(
         eachcol(observation)
     end
 
-    # encoding works on columns but mcmc wants vec-of-vec
+    # encoding data works on columns but mcmc wants vec-of-vec
     encoded_obs = [vec(encode_data(em_or_fmw, reshape(obs, :, 1), "out")) for obs in obs_slice]
+    # encoding initial condition
+    #encoded_init_params = vec(encode_data(em_or_fmw, reshape(init_params,:,1), "in"))
 
     log_posterior_map = EmulatorPosteriorModel(prior, em_or_fmw, encoded_obs)
     mh_proposal_sampler = MetropolisHastingsSampler(mcmc_alg, prior)
@@ -594,6 +596,7 @@ function MCMCWrapper(
     end
 
     sample_kwargs = (; # set defaults here
+#        :initial_params => deepcopy(encoded_init_params),
         :initial_params => deepcopy(init_params),
         :param_names => param_names,
         :discard_initial => burnin,

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -795,7 +795,17 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
     p_chain = Array(Chains(chain, :parameters)) # discard internal/diagnostic data
     # get the encoding schedule for decoding
     encoder_schedule = get_encoder_schedule(mcmc)
-    p_samples = [Samples(decode_data(encoder_schedule, p_chain[:, slice, 1], "in"), params_are_columns = false) for slice in p_slices]
+    dec_samples = Matrix(decode_data(encoder_schedule, p_chain[:, slice, 1], "in"))
+    # add sample from null space:
+    prior_samples = sample(mcmc.prior, size(decoded_inputs,2))
+    null_samples = prior_samples - Matrix(decode_data(
+        encoder_schedule,
+        encode_data(encoder_schedule, prior_samples, "in"),
+        "in",
+    ))
+    dec_samples .+= null_samples
+    
+    p_samples = [Samples(dec_samples, params_are_columns = false) for slice in p_slices]
 
     # live in same space as prior
     # checks if a function distribution, by looking at if the distribution is nested

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -560,11 +560,7 @@ function MCMCWrapper(
     init_params::AV = [],
     burnin::Int = 0,
     kwargs...,
-) where {
-    AV <: AbstractVector,
-    AMorAV <: Union{AbstractVector, AbstractMatrix},
-    EorFMW <: Union{Emulator, ForwardMapWrapper},
-}
+) where {AV <: AbstractVector, AMorAV <: Union{AbstractVector, AbstractMatrix}, EorFMW <: Union{Emulator, ForwardMapWrapper}}
 
     if length(init_params) == 0
         init_params = mean(prior)

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -41,20 +41,20 @@ export EmulatorPosteriorModel,
     esjd,
 
 
-# ------------------------------------------------------------------------------------------
-# Sampler extensions to differentiate vanilla RW and pCN algorithms
-#
-# (Strictly speaking the difference between RW and pCN should be implemented at the level of
-# the MH Sampler's Proposal, not by defining a new Sampler, since the former is where the 
-# only change is made. We do the latter here because doing the former would require more
-# boilerplate code (repeating AdvancedMH/src/proposal.jl for the new Proposals)).
+    # ------------------------------------------------------------------------------------------
+    # Sampler extensions to differentiate vanilla RW and pCN algorithms
+    #
+    # (Strictly speaking the difference between RW and pCN should be implemented at the level of
+    # the MH Sampler's Proposal, not by defining a new Sampler, since the former is where the 
+    # only change is made. We do the latter here because doing the former would require more
+    # boilerplate code (repeating AdvancedMH/src/proposal.jl for the new Proposals)).
 
-# some possible types of autodiff used
-"""
-$(DocStringExtensions.TYPEDEF)
+    # some possible types of autodiff used
+    """
+    $(DocStringExtensions.TYPEDEF)
 
-Type used to dispatch different autodifferentiation methods where different emulators have a different compatability with autodiff packages 
-"""
+    Type used to dispatch different autodifferentiation methods where different emulators have a different compatability with autodiff packages 
+    """
 abstract type AutodiffProtocol end
 
 """
@@ -260,7 +260,7 @@ function emulator_log_density_model(
     # Returned g is a length-1, Vector{Real} or Vector{Vector}, and g_cov is length-1 Vector{Vector} or Vector{Matrix} respectively
     g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode = "in_and_out", add_obs_noise_cov = true)
 
-    decoded_θ = vec(decode_data(em_or_fmw, reshape(θ,:,1), "in")) # to compute logpdf(prior, θ) -> in full space
+    decoded_θ = vec(decode_data(em_or_fmw, reshape(θ, :, 1), "in")) # to compute logpdf(prior, θ) -> in full space
 
     if isa(g_cov[1], Real)
         return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(prior, θ)
@@ -509,7 +509,7 @@ AbstractMCMC's terminology).
 # Fields
 $(DocStringExtensions.TYPEDFIELDS)
 """
-struct MCMCWrapper{VV1 <: AbstractVector, VV2 <: AbstractVector, VV3<: AbstractVector}
+struct MCMCWrapper{VV1 <: AbstractVector, VV2 <: AbstractVector, VV3 <: AbstractVector}
     "[`ParameterDistribution`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parameter_distributions/) object describing the prior distribution on parameter values."
     prior::ParameterDistribution
     "[output_dim x N_samples] matrix, of given observation data."
@@ -593,28 +593,35 @@ function MCMCWrapper(
     end
 
     # encoding, saved in MCMCWrapper
-    encoder_schedule= get_encoder_schedule(em_or_fmw)
-    
+    encoder_schedule = get_encoder_schedule(em_or_fmw)
+
     # encoding data works on columns but mcmc wants vec-of-vec
     encoded_obs = [vec(encode_data(encoder_schedule, reshape(obs, :, 1), "out")) for obs in obs_slice]
     # encoding initial condition
-    encoded_init_params = vec(encode_data(encoder_schedule, reshape(init_params,:,1), "in"))
-    
+    encoded_init_params = vec(encode_data(encoder_schedule, reshape(init_params, :, 1), "in"))
+
     log_posterior_map = EmulatorPosteriorModel(prior, em_or_fmw, encoded_obs)
     mh_proposal_sampler = MetropolisHastingsSampler(mcmc_alg, prior)
 
     # naming encoded dimensions
-    param_names = ["encoded_param_$(k)" for k in 1:size(encoded_init_params,1)]
-    
-    sample_kwargs = (
-        ; # set defaults here
+    param_names = ["encoded_param_$(k)" for k in 1:size(encoded_init_params, 1)]
+
+    sample_kwargs = (; # set defaults here
         :initial_params => deepcopy(encoded_init_params),
         :param_names => param_names,
         :discard_initial => burnin,
         :chain_type => MCMCChains.Chains,
     )
     sample_kwargs = merge(sample_kwargs, kwargs) # override defaults with any explicit values
-    return MCMCWrapper(prior, obs_slice, encoded_obs, log_posterior_map, mh_proposal_sampler, sample_kwargs, encoder_schedule)
+    return MCMCWrapper(
+        prior,
+        obs_slice,
+        encoded_obs,
+        log_posterior_map,
+        mh_proposal_sampler,
+        sample_kwargs,
+        encoder_schedule,
+    )
 end
 
 function MCMCWrapper(
@@ -789,7 +796,7 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
     p_slices = batch(mcmc.prior)
     flat_constraints = get_all_constraints(mcmc.prior)
 
-    
+
     # Cast data in chain to a ParameterDistribution object. Data layout in Chain is an
     # (N_samples x n_params x n_chains) AxisArray, so samples are in rows.
     p_chain = Array(Chains(chain, :parameters)) # discard internal/diagnostic data
@@ -797,14 +804,11 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
     encoder_schedule = get_encoder_schedule(mcmc)
     dec_samples = Matrix(decode_data(encoder_schedule, p_chain[:, slice, 1], "in"))
     # add sample from null space:
-    prior_samples = sample(mcmc.prior, size(decoded_inputs,2))
-    null_samples = prior_samples - Matrix(decode_data(
-        encoder_schedule,
-        encode_data(encoder_schedule, prior_samples, "in"),
-        "in",
-    ))
+    prior_samples = sample(mcmc.prior, size(decoded_inputs, 2))
+    null_samples =
+        prior_samples - Matrix(decode_data(encoder_schedule, encode_data(encoder_schedule, prior_samples, "in"), "in"))
     dec_samples .+= null_samples
-    
+
     p_samples = [Samples(dec_samples, params_are_columns = false) for slice in p_slices]
 
     # live in same space as prior

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -39,8 +39,7 @@ export EmulatorPosteriorModel,
     get_sample_kwargs,
     get_encoder_schedule,
     sample,
-    esjd,
-    decode_and_add_noise
+    esjd
 
 # ------------------------------------------------------------------------------------------
 # Sampler extensions to differentiate vanilla RW and pCN algorithms
@@ -85,16 +84,11 @@ abstract type ZygoteProtocol <: AutodiffProtocol end
 abstract type EnzymeProtocol <: AutodiffProtocol end
 =#
 
-function _get_proposal(prior::ParameterDistribution, encoder_schedule::VV) where {VV <: AbstractVector}
+function _get_proposal(encoded_prior::ParameterDistribution, encoder_schedule::VV) where {VV <: AbstractVector}
     # We use the prior covariance to shape the proposal (in the encoded space), 
     # as proposals are based on increments we do not need to shift the mean too
-    C = cov(prior)
-    E, _ = get_encoder_from_schedule(encoder_schedule, "in")
-    if isnothing(E)
-        Σ = cholesky(Symmetric(C + 1e-12I))
-    else
-        Σ = cholesky(Symmetric(Matrix(E) * C * Matrix(E)' + 1e-12 * I))
-    end
+    C = cov(encoded_prior)
+    Σ = cholesky(Symmetric(C))
 
     return AdvancedMH.RandomWalkProposal(Σ.L * MvNormal(zeros(size(Σ, 1)), I))
 end
@@ -145,10 +139,10 @@ Constructor for all `Sampler` objects, with one method for each supported MCMC a
 """
 function MetropolisHastingsSampler(
     ::RWMHSampling{T},
-    prior::ParameterDistribution,
+    encoded_prior::ParameterDistribution,
     encoder_schedule::VV,
 ) where {T <: AutodiffProtocol, VV <: AbstractVector}
-    proposal = _get_proposal(prior, encoder_schedule)
+    proposal = _get_proposal(encoded_prior, encoder_schedule)
     return RWMetropolisHastings{typeof(proposal), T}(proposal)
 end
 
@@ -174,10 +168,10 @@ AdvancedMH.logratio_proposal_density(
 ) = AdvancedMH.logratio_proposal_density(sampler.proposal, transition_prev.params, candidate)
 function MetropolisHastingsSampler(
     ::pCNMHSampling{T},
-    prior::ParameterDistribution,
+    encoded_prior::ParameterDistribution,
     encoder_schedule::VV,
 ) where {T <: AutodiffProtocol, VV <: AbstractVector}
-    proposal = _get_proposal(prior, encoder_schedule)
+    proposal = _get_proposal(encoded_prior, encoder_schedule)
     return pCNMetropolisHastings{typeof(proposal), T}(proposal)
 end
 
@@ -204,10 +198,10 @@ AdvancedMH.logratio_proposal_density(
 
 function MetropolisHastingsSampler(
     ::BarkerSampling{T},
-    prior::ParameterDistribution,
+    encoded_prior::ParameterDistribution,
     encoder_schedule::VV,
 ) where {T <: AutodiffProtocol, VV <: AbstractVector}
-    proposal = _get_proposal(prior, encoder_schedule)
+    proposal = _get_proposal(encoded_prior, encoder_schedule)
     return BarkerMetropolisHastings{typeof(proposal), T}(proposal)
 end
 
@@ -264,13 +258,13 @@ Defines the internal log-density function over a vector of observation samples u
 Inputs:
 =======
 - θ: Parameters in unconstrained, and encoded coordinates.
-- prior: Prior distribution as a ParameterDistribution (defined on the full, decoded and unconstrained space)
+- encoded_prior: Encoded prior distribution as a ParameterDistribution (defined on the unconstrained, and encoded coordinates)
 - em_or_fmw: `Emulator` or `ForwardMapWrapper` object with predict(.) method
 - obs_vec: encoded data vector sample(s)
 """
 function emulator_log_density_model(
     θ,
-    prior::ParameterDistribution,
+    encoded_prior::ParameterDistribution,
     em_or_fmw::EorFMW,
     obs_vec::AV,
 ) where {AV <: AbstractVector, EorFMW <: Union{Emulator, ForwardMapWrapper}}
@@ -278,12 +272,10 @@ function emulator_log_density_model(
     # Returned g is a length-1, Vector{Real} or Vector{Vector}, and g_cov is length-1 Vector{Vector} or Vector{Matrix} respectively
     g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode = "in_and_out", add_obs_noise_cov = true)
 
-    decoded_θ = vec(decode_data(em_or_fmw, reshape(θ, :, 1), "in")) # we still compute logpdf(prior, decoded_θ) in full space, where prior is defined
-
     if isa(g_cov[1], Real)
-        return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(prior, decoded_θ)
+        return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(encoded_prior, θ)
     else
-        return sum([logpdf(MvNormal(obs, g_cov[1]), vec(g)) for obs in obs_vec]) + logpdf(prior, decoded_θ)
+        return sum([logpdf(MvNormal(obs, g_cov[1]), vec(g)) for obs in obs_vec]) + logpdf(encoded_prior, θ)
     end
 
 end
@@ -291,18 +283,18 @@ end
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
-Factory which constructs `AdvancedMH.DensityModel` objects given a prior on the model 
-parameters (`prior`) and an [`Emulator`](@ref) of the log-likelihood of the data given 
+Factory which constructs `AdvancedMH.DensityModel` objects given an (Encoded) prior on the model 
+parameters (`encoded_prior`) and an [`Emulator`](@ref) of the log-likelihood of the data given 
 parameters. Together these yield the log posterior density we're attempting to sample from 
 with the MCMC, which is the role of the `DensityModel` class in the `AbstractMCMC` interface.
 """
 function EmulatorPosteriorModel(
-    prior::ParameterDistribution,
+    encoded_prior::ParameterDistribution,
     em_or_fmw::EorFMW,
     obs_vec::AV,
 ) where {AV <: AbstractVector, EorFMW <: Union{Emulator, ForwardMapWrapper}}
 
-    return AdvancedMH.DensityModel(x -> emulator_log_density_model(x, prior, em_or_fmw, obs_vec))
+    return AdvancedMH.DensityModel(x -> emulator_log_density_model(x, encoded_prior, em_or_fmw, obs_vec))
 end
 
 # ------------------------------------------------------------------------------------------
@@ -530,6 +522,8 @@ $(DocStringExtensions.TYPEDFIELDS)
 struct MCMCWrapper{VV1 <: AbstractVector, VV2 <: AbstractVector, VV3 <: AbstractVector}
     "[`ParameterDistribution`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parameter_distributions/) object describing the prior distribution on parameter values."
     prior::ParameterDistribution
+    "[`ParameterDistribution`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parameter_distributions/) object describing the encoded prior distribution on the encoded parameter values."
+    encoded_prior::ParameterDistribution
     "[output_dim x N_samples] matrix, of given observation data."
     observations::VV1
     "Vector of observations describing the data samples to actually used during MCMC sampling (that have been transformed into a space consistent with emulator outputs)."
@@ -608,16 +602,35 @@ function MCMCWrapper(
         eachcol(observation)
     end
 
-    # encoding, saved in MCMCWrapper
+    # encodings! Saved in MCMCWrapper
+    # We encode (1) data, (2) initial params (3) prior
     encoder_schedule = get_encoder_schedule(em_or_fmw)
 
     # encoding data works on columns but mcmc wants vec-of-vec
     encoded_obs = [vec(encode_data(encoder_schedule, reshape(obs, :, 1), "out")) for obs in obs_slice]
     # encoding initial condition
     encoded_init_params = vec(encode_data(encoder_schedule, reshape(init_params, :, 1), "in"))
+    # encoding the prior (Gaussian assumptions)
+    mp = ndims(prior) == 1 ? [mean(prior)] : mean(prior)
+    cp = cov(prior)
+    encoded_mean = vec(encode_data(encoder_schedule, reshape(mp, :, 1), "in"))
+    encoded_cov = Matrix(encode_structure_matrix(encoder_schedule, cov(prior), "in"))
+    if size(encoded_init_params, 1) == 1 # 1D
+        enc_dist = Parameterized(Normal(encoded_mean[1], sqrt(encoded_cov[1]))) #N(μ,σ)
+    else
+        enc_dist = Parameterized(MvNormal(encoded_mean, Symmetric(encoded_cov) + 1e-12I)) # N(m,0.5*(C+C'))
+    end
+    encoded_prior = ParameterDistribution(
+        Dict(
+            "distribution" => enc_dist,
+            "constraint" => repeat([no_constraint()], length(encoded_mean)),
+            "name" => "encoded_prior_gaussian_$(length(encoded_mean))D",
+        ),
+    )
 
-    log_posterior_map = EmulatorPosteriorModel(prior, em_or_fmw, encoded_obs)
-    mh_proposal_sampler = MetropolisHastingsSampler(mcmc_alg, prior, encoder_schedule)
+    # pass in encoded prior here. (Only use decoded prior for final decoding of posterior)
+    log_posterior_map = EmulatorPosteriorModel(encoded_prior, em_or_fmw, encoded_obs)
+    mh_proposal_sampler = MetropolisHastingsSampler(mcmc_alg, encoded_prior, encoder_schedule)
 
     # naming encoded dimensions
     param_names = ["encoded_param_$(k)" for k in 1:size(encoded_init_params, 1)]
@@ -631,6 +644,7 @@ function MCMCWrapper(
     sample_kwargs = merge(sample_kwargs, kwargs) # override defaults with any explicit values
     return MCMCWrapper(
         prior,
+        encoded_prior,
         obs_slice,
         encoded_obs,
         log_posterior_map,
@@ -796,50 +810,6 @@ function optimize_stepsize(
 end
 # use default rng if none given
 optimize_stepsize(mcmc::MCMCWrapper; kwargs...) = optimize_stepsize(Random.GLOBAL_RNG, mcmc; kwargs...)
-
-
-"""
-$(TYPEDSIGNATURES)
-
-Lift back the encoded samples into the full space. Similar to using `decode_data`, except that this additionally injects noise from the prior when the encoding is determined to be sufficiently lossy (total lost variance < keyword `boost_for_loss`). This is done in a way that preserves any known correlations between reduced and null-space directions, which is important for posterior reconstruction.
-
-The quantification of correlation depends on Gaussian assumptions, and therefore is approximate. 
-"""
-function decode_and_add_noise(
-    encoder_schedule::VV,
-    samples::MM,
-    prior::PD,
-    boost_for_loss::FT,
-) where {MM <: AbstractMatrix, PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
-
-    E, b = get_encoder_from_schedule(encoder_schedule, "in") # encoder is affine: E*x + b
-    if isnothing(E)
-        return samples
-    end
-
-    C = cov(prior)
-    m = reshape(mean(prior), :, 1)
-    E = Matrix(E)
-    enc_m = (E * m + b)
-    ECEt = cholesky(Symmetric(E * C * E' + 1e-12 * I))
-    K = C * E' * (ECEt \ I) # Gain
-    Σ_cond = C - K * E * C
-    projection_loss = tr(Σ_cond) / tr(C)
-    if projection_loss > boost_for_loss # (default >0.1% of variance is lost in projecting)
-        @info "As the variance lost in reduced space is sufficiently large: $(projection_loss) > boost_for_loss (= $(boost_for_loss)), we inject additional noise into the complement of the reduced space"
-        recovered_samples = m .+ K * (samples .- enc_m) # similar to `decode_data`
-
-        # Conditionally sample from the null space to preserve correlations with the reduced samples
-        L = cholesky(Symmetric(Σ_cond + 1e-12 * I)).L
-        null_samples = L * randn(size(C, 1), size(samples, 2))
-        full_samples = null_samples + recovered_samples
-    else
-        # more consistent to return decoded_samples than recovered samples
-        full_samples = decode_data(encoder_schedule, samples, "in")
-    end
-
-    return full_samples
-end
 
 """
 $(DocStringExtensions.TYPEDSIGNATURES)

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -2,7 +2,6 @@
 module MarkovChainMonteCarlo
 
 using ..Emulators
-import get_encoder_schedule
 
 using ..ParameterDistributions
 using ..EnsembleKalmanProcesses
@@ -38,8 +37,7 @@ export EmulatorPosteriorModel,
     get_sample_kwargs,
     get_encoder_schedule,
     sample,
-    esjd,
-
+    esjd
 
     # ------------------------------------------------------------------------------------------
     # Sampler extensions to differentiate vanilla RW and pCN algorithms
@@ -50,11 +48,12 @@ export EmulatorPosteriorModel,
     # boilerplate code (repeating AdvancedMH/src/proposal.jl for the new Proposals)).
 
     # some possible types of autodiff used
-    """
-    $(DocStringExtensions.TYPEDEF)
 
-    Type used to dispatch different autodifferentiation methods where different emulators have a different compatability with autodiff packages 
-    """
+"""
+$(DocStringExtensions.TYPEDEF)
+
+Type used to dispatch different autodifferentiation methods where different emulators have a different compatability with autodiff packages 
+"""
 abstract type AutodiffProtocol end
 
 """
@@ -800,17 +799,30 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
     # Cast data in chain to a ParameterDistribution object. Data layout in Chain is an
     # (N_samples x n_params x n_chains) AxisArray, so samples are in rows.
     p_chain = Array(Chains(chain, :parameters)) # discard internal/diagnostic data
+
     # get the encoding schedule for decoding
     encoder_schedule = get_encoder_schedule(mcmc)
-    dec_samples = Matrix(decode_data(encoder_schedule, p_chain[:, slice, 1], "in"))
-    # add sample from null space:
-    prior_samples = sample(mcmc.prior, size(decoded_inputs, 2))
-    null_samples =
-        prior_samples - Matrix(decode_data(encoder_schedule, encode_data(encoder_schedule, prior_samples, "in"), "in"))
-    dec_samples .+= null_samples
+    # [1] sample randomly from the null space of the encoding and add in
+#    dec_samples = Matrix(decode_data(encoder_schedule, p_chain[:, slice, 1], "in"))
+#    prior_samples = sample(mcmc.prior, size(decoded_inputs, 2))
+#    null_samples =
+#        prior_samples - Matrix(decode_data(encoder_schedule, encode_data(encoder_schedule, prior_samples, "in"), "in"))
+#    dec_samples .+= null_samples
+#    p_samples = [Samples(dec_samples, params_are_columns = false) for slice in p_slices]
 
-    p_samples = [Samples(dec_samples, params_are_columns = false) for slice in p_slices]
+    # [2] conditionally sample from the null space to preserve correlations with the reduced samples
+    red_samples = p_chain[:, slice, 1]
+    C = cov(mcmc.prior)
+    E = encode_data(encoder_schedule, ones(ndims(prior)), "in")
+    ECEt = cholesky(Symmetric(E * C * E'))
+    K = C * E' * inv(ECEt) # Kalman Gain
+    # then compute μ + K(z-Eμ) + (I-KE)η
+    sn_samples = randn(size(red_samples))
+    full_samples = mean(prior) .+ K*(red_samples .- E*mean(prior)) + (I-K*E)*sn_samples
+    
+    p_samples = [Samples(full_samples, params_are_columns = false) for slice in p_slices]
 
+     
     # live in same space as prior
     # checks if a function distribution, by looking at if the distribution is nested
     p_constraints = [

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -84,10 +84,14 @@ abstract type ZygoteProtocol <: AutodiffProtocol end
 abstract type EnzymeProtocol <: AutodiffProtocol end
 =#
 
-function _get_proposal(prior::ParameterDistribution)
-    # *only* use covariance of prior, not full distribution
-    Σsqrt = sqrt(ParameterDistributions.cov(prior)) # rt_cov * MVN(0,I) avoids the posdef errors for MVN in Julia Distributions   
-    return AdvancedMH.RandomWalkProposal(Σsqrt * MvNormal(zeros(size(Σsqrt)[1]), I))
+function _get_proposal(prior::ParameterDistribution, encoder_schedule::VV) where {VV <: AbstractVector}
+    # We use the prior covariance to shape the proposal (in the encoded space), 
+    # as proposals are based on increments we do not need to shift the mean too
+    E,_ = get_encoder_from_schedule(encoder_schedule, "in")
+    C = cov(prior) 
+    Σ = Matrix(E) * C * Matrix(E)'
+    Σ = cholesky(Symmetric(Σ + 1e-12I))
+    return AdvancedMH.RandomWalkProposal(Σ.L * MvNormal(zeros(size(Σ, 1)), I))
 end
 
 
@@ -134,8 +138,8 @@ Constructor for all `Sampler` objects, with one method for each supported MCMC a
     (possibly in a transformed space) and we assume enough fidelity in the Emulator that 
     inference isn't prior-dominated.
 """
-function MetropolisHastingsSampler(::RWMHSampling{T}, prior::ParameterDistribution) where {T <: AutodiffProtocol}
-    proposal = _get_proposal(prior)
+function MetropolisHastingsSampler(::RWMHSampling{T}, prior::ParameterDistribution, encoder_schedule::VV) where {T <: AutodiffProtocol, VV <: AbstractVector}
+    proposal = _get_proposal(prior, encoder_schedule)
     return RWMetropolisHastings{typeof(proposal), T}(proposal)
 end
 
@@ -159,8 +163,8 @@ AdvancedMH.logratio_proposal_density(
     transition_prev::AdvancedMH.AbstractTransition,
     candidate,
 ) = AdvancedMH.logratio_proposal_density(sampler.proposal, transition_prev.params, candidate)
-function MetropolisHastingsSampler(::pCNMHSampling{T}, prior::ParameterDistribution) where {T <: AutodiffProtocol}
-    proposal = _get_proposal(prior)
+function MetropolisHastingsSampler(::pCNMHSampling{T}, prior::ParameterDistribution, encoder_schedule::VV) where {T <: AutodiffProtocol, VV <: AbstractVector}
+    proposal = _get_proposal(prior, encoder_schedule)
     return pCNMetropolisHastings{typeof(proposal), T}(proposal)
 end
 
@@ -185,8 +189,8 @@ AdvancedMH.logratio_proposal_density(
     candidate,
 ) = AdvancedMH.logratio_proposal_density(sampler.proposal, transition_prev.params, candidate)
 
-function MetropolisHastingsSampler(::BarkerSampling{T}, prior::ParameterDistribution) where {T <: AutodiffProtocol}
-    proposal = _get_proposal(prior)
+function MetropolisHastingsSampler(::BarkerSampling{T}, prior::ParameterDistribution, encoder_schedule::VV) where {T <: AutodiffProtocol, VV <: AbstractVector}
+    proposal = _get_proposal(prior, encoder_schedule)
     return BarkerMetropolisHastings{typeof(proposal), T}(proposal)
 end
 
@@ -602,7 +606,7 @@ function MCMCWrapper(
     encoded_init_params = vec(encode_data(encoder_schedule, reshape(init_params, :, 1), "in"))
 
     log_posterior_map = EmulatorPosteriorModel(prior, em_or_fmw, encoded_obs)
-    mh_proposal_sampler = MetropolisHastingsSampler(mcmc_alg, prior)
+    mh_proposal_sampler = MetropolisHastingsSampler(mcmc_alg, prior, encoder_schedule)
 
     # naming encoded dimensions
     param_names = ["encoded_param_$(k)" for k in 1:size(encoded_init_params, 1)]
@@ -792,7 +796,7 @@ samples in `chain`.
 !!! note
     This method does not currently support combining samples from multiple `Chains`.
 """
-function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains, boost_for_loss=0.001)
+function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_loss=0.001)
     p_names = get_name(mcmc.prior)
     p_slices = batch(mcmc.prior)
     flat_constraints = get_all_constraints(mcmc.prior)
@@ -804,8 +808,8 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains, boost_for_lo
     # get the encoding schedule for decoding
     encoder_schedule = get_encoder_schedule(mcmc)
     
-    # flatten samples from the chain for manipulation
-    red_samples = reduce(vcat, [p_chain[:, slice, 1]' for slice in p_slices])
+    # flatten samples from the chain for manipulation as an array with columns as samples
+    red_samples = p_chain[:, :, 1]'
     
     # Perform a lift back to the full-space, that is aware of the correlation between reduced and null-space variables (through a Gaussian assumption)
     # Can be done by defining the deterministic Gaussin gain K, to decode, then if the null-space "(I-KE)" is big we also inject noise in the null space

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -792,11 +792,10 @@ samples in `chain`.
 !!! note
     This method does not currently support combining samples from multiple `Chains`.
 """
-function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
+function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains, boost_for_loss=0.001)
     p_names = get_name(mcmc.prior)
     p_slices = batch(mcmc.prior)
     flat_constraints = get_all_constraints(mcmc.prior)
-
 
     # Cast data in chain to a ParameterDistribution object. Data layout in Chain is an
     # (N_samples x n_params x n_chains) AxisArray, so samples are in rows.
@@ -805,28 +804,32 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
     # get the encoding schedule for decoding
     encoder_schedule = get_encoder_schedule(mcmc)
     
-    # [for testing - just decode]
-    to_be_dec_samples = reduce(vcat, [p_chain[:, slice, 1]' for slice in p_slices])
-    dec_samples = decode_data(encoder_schedule, to_be_dec_samples, "in")
-    p_samples = [Samples(dec_samples[slice,:], params_are_columns = true) for slice in p_slices]
-
-    
-    # Conditionally sample from the null space to preserve correlations with the reduced samples
-
-    #=
+    # flatten samples from the chain for manipulation
     red_samples = reduce(vcat, [p_chain[:, slice, 1]' for slice in p_slices])
-    C = cov(mcmc.prior)
-    E = Matrix(get_encoder_from_schedule(encoder_schedule, "in"))
-
-    ECEt = cholesky(Symmetric(E * C * E'))
-    K = C * E' * inv(ECEt) # Kalman Gain    
     
-    # then compute μ + K(z-Eμ) + (I-KE)η
-    sn_samples = randn(size(red_samples))
-    full_samples = mean(mcmc.prior) .+ K*(red_samples .- E*mean(mcmc.prior)) + (I-K*E)*sn_samples
+    # Perform a lift back to the full-space, that is aware of the correlation between reduced and null-space variables (through a Gaussian assumption)
+    # Can be done by defining the deterministic Gaussin gain K, to decode, then if the null-space "(I-KE)" is big we also inject noise in the null space
+    C = cov(mcmc.prior)
+    m = reshape(mean(mcmc.prior), : ,1)
+    E, b = get_encoder_from_schedule(encoder_schedule, "in") # encoder is affine: E*x + b
+    E = Matrix(E)
+    enc_m = (E*m + b)
+    ECEt = cholesky(Symmetric(E * C * E' + 1e-12*I))
+    K = C * E' * (ECEt \ I) # Gain
+    # deterministic reconstruction with the Gain (should be similar to decode_data(...))
+    full_samples = m .+ K*(red_samples .- enc_m)
+
+    projection_loss = tr(C-K*E*C) / tr(C)
+    if projection_loss > boost_for_loss # (default >0.1% of variance is lost in projecting)
+        @info "As the variance lost in reduced space is sufficiently large: $(projection_loss) > boost_for_loss (= $(boost_for_loss)), we inject additional noise into the complement of the reduced space"
+        # Conditionally sample from the null space to preserve correlations with the reduced samples
+        Σ_cond = C - K * E * C
+        L = cholesky(Symmetric(Σ_cond + 1e-12*I)).L
+        null_samples = L * randn(size(C,1), size(red_samples,2))
+        full_samples += null_samples
+    end
     
     p_samples = [Samples(full_samples[slice,:], params_are_columns = true) for slice in p_slices]
-    =#
      
     # live in same space as prior
     # checks if a function distribution, by looking at if the distribution is nested

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -39,7 +39,8 @@ export EmulatorPosteriorModel,
     get_sample_kwargs,
     get_encoder_schedule,
     sample,
-    esjd
+    esjd,
+    decode_and_add_noise
 
 # ------------------------------------------------------------------------------------------
 # Sampler extensions to differentiate vanilla RW and pCN algorithms
@@ -804,6 +805,42 @@ optimize_stepsize(mcmc::MCMCWrapper; kwargs...) = optimize_stepsize(Random.GLOBA
 
 
 """
+$(TYPEDSIGNATURES)
+
+Lift back the encoded samples into the full space. Similar to using `decode_data`, except that this additionally injects noise from the prior when the encoding is determined to be sufficiently lossy (total lost variance < keyword `boost_for_loss`). This is done in a way that preserves any known correlations between reduced and null-space directions, which is important for posterior reconstruction.
+"""
+function decode_and_add_noise(encoder_schedule::VV, samples::MM, prior::PD, boost_for_loss::FT) where {MM <: AbstractMatrix, PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
+        
+    E, b = get_encoder_from_schedule(encoder_schedule, "in") # encoder is affine: E*x + b
+    if isnothing(E)
+        return samples
+    end
+    
+    C = cov(prior)
+    m = reshape(mean(prior), :, 1)
+    E = Matrix(E)
+    enc_m = (E * m + b)
+    ECEt = cholesky(Symmetric(E * C * E' + 1e-12*I))
+    K = C * E' * (ECEt \ I) # Gain
+    Σ_cond = C - K * E * C    
+    projection_loss = tr(Σ_cond) / tr(C)
+    if projection_loss > boost_for_loss # (default >0.1% of variance is lost in projecting)
+        @info "As the variance lost in reduced space is sufficiently large: $(projection_loss) > boost_for_loss (= $(boost_for_loss)), we inject additional noise into the complement of the reduced space"
+        recovered_samples = m .+ K * (samples .- enc_m) # similar to `decode_data`
+
+        # Conditionally sample from the null space to preserve correlations with the reduced samples
+        L = cholesky(Symmetric(Σ_cond + 1e-12 * I)).L
+        null_samples = L * randn(size(C, 1), size(samples, 2))
+        full_samples = null_samples + recovered_samples
+    else
+        # more consistent to return decoded_samples than recovered samples
+        full_samples = decode_data(encoder_schedule, samples, "in")
+    end
+
+    return full_samples
+end
+
+"""
 $(DocStringExtensions.TYPEDSIGNATURES)
 
 Returns a `ParameterDistribution` object corresponding to the empirical distribution of the 
@@ -826,34 +863,8 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_lo
 
     # flatten samples from the chain for manipulation as an array with columns as samples
     red_samples = p_chain[:, :, 1]'
-
-    E, b = get_encoder_from_schedule(encoder_schedule, "in") # encoder is affine: E*x + b
-    if isnothing(E)
-        full_samples = red_samples
-    else
-        # Perform a lift back to the full-space, that is aware of the correlation between reduced and null-space variables (through a Gaussian assumption)
-        # Can be done by defining the deterministic Gaussin gain K, to decode, then if the null-space "(I-KE)" is big we also inject noise in the null space
-
-        C = cov(mcmc.prior)
-        m = reshape(mean(mcmc.prior), :, 1)
-        E = Matrix(E)
-        enc_m = (E * m + b)
-        ECEt = cholesky(Symmetric(E * C * E' + 1e-12 * I))
-        K = C * E' * (ECEt \ I) # Gain
-        # deterministic reconstruction with the Gain (should be similar to decode_data(...))
-        full_samples = m .+ K * (red_samples .- enc_m)
-
-        projection_loss = tr(C - K * E * C) / tr(C)
-        if projection_loss > boost_for_loss # (default >0.1% of variance is lost in projecting)
-            @info "As the variance lost in reduced space is sufficiently large: $(projection_loss) > boost_for_loss (= $(boost_for_loss)), we inject additional noise into the complement of the reduced space"
-            # Conditionally sample from the null space to preserve correlations with the reduced samples
-            Σ_cond = C - K * E * C
-            L = cholesky(Symmetric(Σ_cond + 1e-12 * I)).L
-            null_samples = L * randn(size(C, 1), size(red_samples, 2))
-            full_samples += null_samples
-        end
-    end
-
+    full_samples = decode_and_add_noise(encoder_schedule, red_samples, mcmc.prior, boost_for_loss)
+    
     p_samples = [Samples(full_samples[slice, :], params_are_columns = true) for slice in p_slices]
 
     # live in same space as prior

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -255,7 +255,7 @@ function emulator_log_density_model(
 
     # predict is written to apply to columns.
     # Returned g is a length-1, Vector{Real} or Vector{Vector}, and g_cov is length-1 Vector{Vector} or Vector{Matrix} respectively
-    g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode="out", add_obs_noise_cov=true)
+    g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode = "out", add_obs_noise_cov = true)
 
     if isa(g_cov[1], Real)
         return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(prior, θ)
@@ -596,7 +596,7 @@ function MCMCWrapper(
     end
 
     sample_kwargs = (; # set defaults here
-#        :initial_params => deepcopy(encoded_init_params),
+        #        :initial_params => deepcopy(encoded_init_params),
         :initial_params => deepcopy(init_params),
         :param_names => param_names,
         :discard_initial => burnin,

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -41,15 +41,15 @@ export EmulatorPosteriorModel,
     sample,
     esjd
 
-    # ------------------------------------------------------------------------------------------
-    # Sampler extensions to differentiate vanilla RW and pCN algorithms
-    #
-    # (Strictly speaking the difference between RW and pCN should be implemented at the level of
-    # the MH Sampler's Proposal, not by defining a new Sampler, since the former is where the 
-    # only change is made. We do the latter here because doing the former would require more
-    # boilerplate code (repeating AdvancedMH/src/proposal.jl for the new Proposals)).
+# ------------------------------------------------------------------------------------------
+# Sampler extensions to differentiate vanilla RW and pCN algorithms
+#
+# (Strictly speaking the difference between RW and pCN should be implemented at the level of
+# the MH Sampler's Proposal, not by defining a new Sampler, since the former is where the 
+# only change is made. We do the latter here because doing the former would require more
+# boilerplate code (repeating AdvancedMH/src/proposal.jl for the new Proposals)).
 
-    # some possible types of autodiff used
+# some possible types of autodiff used
 
 """
 $(DocStringExtensions.TYPEDEF)
@@ -87,8 +87,8 @@ abstract type EnzymeProtocol <: AutodiffProtocol end
 function _get_proposal(prior::ParameterDistribution, encoder_schedule::VV) where {VV <: AbstractVector}
     # We use the prior covariance to shape the proposal (in the encoded space), 
     # as proposals are based on increments we do not need to shift the mean too
-    E,_ = get_encoder_from_schedule(encoder_schedule, "in")
-    C = cov(prior) 
+    E, _ = get_encoder_from_schedule(encoder_schedule, "in")
+    C = cov(prior)
     Σ = Matrix(E) * C * Matrix(E)'
     Σ = cholesky(Symmetric(Σ + 1e-12I))
     return AdvancedMH.RandomWalkProposal(Σ.L * MvNormal(zeros(size(Σ, 1)), I))
@@ -138,7 +138,11 @@ Constructor for all `Sampler` objects, with one method for each supported MCMC a
     (possibly in a transformed space) and we assume enough fidelity in the Emulator that 
     inference isn't prior-dominated.
 """
-function MetropolisHastingsSampler(::RWMHSampling{T}, prior::ParameterDistribution, encoder_schedule::VV) where {T <: AutodiffProtocol, VV <: AbstractVector}
+function MetropolisHastingsSampler(
+    ::RWMHSampling{T},
+    prior::ParameterDistribution,
+    encoder_schedule::VV,
+) where {T <: AutodiffProtocol, VV <: AbstractVector}
     proposal = _get_proposal(prior, encoder_schedule)
     return RWMetropolisHastings{typeof(proposal), T}(proposal)
 end
@@ -163,7 +167,11 @@ AdvancedMH.logratio_proposal_density(
     transition_prev::AdvancedMH.AbstractTransition,
     candidate,
 ) = AdvancedMH.logratio_proposal_density(sampler.proposal, transition_prev.params, candidate)
-function MetropolisHastingsSampler(::pCNMHSampling{T}, prior::ParameterDistribution, encoder_schedule::VV) where {T <: AutodiffProtocol, VV <: AbstractVector}
+function MetropolisHastingsSampler(
+    ::pCNMHSampling{T},
+    prior::ParameterDistribution,
+    encoder_schedule::VV,
+) where {T <: AutodiffProtocol, VV <: AbstractVector}
     proposal = _get_proposal(prior, encoder_schedule)
     return pCNMetropolisHastings{typeof(proposal), T}(proposal)
 end
@@ -189,7 +197,11 @@ AdvancedMH.logratio_proposal_density(
     candidate,
 ) = AdvancedMH.logratio_proposal_density(sampler.proposal, transition_prev.params, candidate)
 
-function MetropolisHastingsSampler(::BarkerSampling{T}, prior::ParameterDistribution, encoder_schedule::VV) where {T <: AutodiffProtocol, VV <: AbstractVector}
+function MetropolisHastingsSampler(
+    ::BarkerSampling{T},
+    prior::ParameterDistribution,
+    encoder_schedule::VV,
+) where {T <: AutodiffProtocol, VV <: AbstractVector}
     proposal = _get_proposal(prior, encoder_schedule)
     return BarkerMetropolisHastings{typeof(proposal), T}(proposal)
 end
@@ -796,7 +808,7 @@ samples in `chain`.
 !!! note
     This method does not currently support combining samples from multiple `Chains`.
 """
-function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_loss=0.001)
+function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_loss = 0.001)
     p_names = get_name(mcmc.prior)
     p_slices = batch(mcmc.prior)
     flat_constraints = get_all_constraints(mcmc.prior)
@@ -807,34 +819,34 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_lo
 
     # get the encoding schedule for decoding
     encoder_schedule = get_encoder_schedule(mcmc)
-    
+
     # flatten samples from the chain for manipulation as an array with columns as samples
     red_samples = p_chain[:, :, 1]'
-    
+
     # Perform a lift back to the full-space, that is aware of the correlation between reduced and null-space variables (through a Gaussian assumption)
     # Can be done by defining the deterministic Gaussin gain K, to decode, then if the null-space "(I-KE)" is big we also inject noise in the null space
     C = cov(mcmc.prior)
-    m = reshape(mean(mcmc.prior), : ,1)
+    m = reshape(mean(mcmc.prior), :, 1)
     E, b = get_encoder_from_schedule(encoder_schedule, "in") # encoder is affine: E*x + b
     E = Matrix(E)
-    enc_m = (E*m + b)
-    ECEt = cholesky(Symmetric(E * C * E' + 1e-12*I))
+    enc_m = (E * m + b)
+    ECEt = cholesky(Symmetric(E * C * E' + 1e-12 * I))
     K = C * E' * (ECEt \ I) # Gain
     # deterministic reconstruction with the Gain (should be similar to decode_data(...))
-    full_samples = m .+ K*(red_samples .- enc_m)
+    full_samples = m .+ K * (red_samples .- enc_m)
 
-    projection_loss = tr(C-K*E*C) / tr(C)
+    projection_loss = tr(C - K * E * C) / tr(C)
     if projection_loss > boost_for_loss # (default >0.1% of variance is lost in projecting)
         @info "As the variance lost in reduced space is sufficiently large: $(projection_loss) > boost_for_loss (= $(boost_for_loss)), we inject additional noise into the complement of the reduced space"
         # Conditionally sample from the null space to preserve correlations with the reduced samples
         Σ_cond = C - K * E * C
-        L = cholesky(Symmetric(Σ_cond + 1e-12*I)).L
-        null_samples = L * randn(size(C,1), size(red_samples,2))
+        L = cholesky(Symmetric(Σ_cond + 1e-12 * I)).L
+        null_samples = L * randn(size(C, 1), size(red_samples, 2))
         full_samples += null_samples
     end
-    
-    p_samples = [Samples(full_samples[slice,:], params_are_columns = true) for slice in p_slices]
-     
+
+    p_samples = [Samples(full_samples[slice, :], params_are_columns = true) for slice in p_slices]
+
     # live in same space as prior
     # checks if a function distribution, by looking at if the distribution is nested
     p_constraints = [

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -809,20 +809,25 @@ $(TYPEDSIGNATURES)
 
 Lift back the encoded samples into the full space. Similar to using `decode_data`, except that this additionally injects noise from the prior when the encoding is determined to be sufficiently lossy (total lost variance < keyword `boost_for_loss`). This is done in a way that preserves any known correlations between reduced and null-space directions, which is important for posterior reconstruction.
 """
-function decode_and_add_noise(encoder_schedule::VV, samples::MM, prior::PD, boost_for_loss::FT) where {MM <: AbstractMatrix, PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
-        
+function decode_and_add_noise(
+    encoder_schedule::VV,
+    samples::MM,
+    prior::PD,
+    boost_for_loss::FT,
+) where {MM <: AbstractMatrix, PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
+
     E, b = get_encoder_from_schedule(encoder_schedule, "in") # encoder is affine: E*x + b
     if isnothing(E)
         return samples
     end
-    
+
     C = cov(prior)
     m = reshape(mean(prior), :, 1)
     E = Matrix(E)
     enc_m = (E * m + b)
-    ECEt = cholesky(Symmetric(E * C * E' + 1e-12*I))
+    ECEt = cholesky(Symmetric(E * C * E' + 1e-12 * I))
     K = C * E' * (ECEt \ I) # Gain
-    Σ_cond = C - K * E * C    
+    Σ_cond = C - K * E * C
     projection_loss = tr(Σ_cond) / tr(C)
     if projection_loss > boost_for_loss # (default >0.1% of variance is lost in projecting)
         @info "As the variance lost in reduced space is sufficiently large: $(projection_loss) > boost_for_loss (= $(boost_for_loss)), we inject additional noise into the complement of the reduced space"
@@ -864,7 +869,7 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_lo
     # flatten samples from the chain for manipulation as an array with columns as samples
     red_samples = p_chain[:, :, 1]'
     full_samples = decode_and_add_noise(encoder_schedule, red_samples, mcmc.prior, boost_for_loss)
-    
+
     p_samples = [Samples(full_samples[slice, :], params_are_columns = true) for slice in p_slices]
 
     # live in same space as prior

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -87,10 +87,14 @@ abstract type EnzymeProtocol <: AutodiffProtocol end
 function _get_proposal(prior::ParameterDistribution, encoder_schedule::VV) where {VV <: AbstractVector}
     # We use the prior covariance to shape the proposal (in the encoded space), 
     # as proposals are based on increments we do not need to shift the mean too
-    E, _ = get_encoder_from_schedule(encoder_schedule, "in")
     C = cov(prior)
-    Σ = Matrix(E) * C * Matrix(E)'
-    Σ = cholesky(Symmetric(Σ + 1e-12I))
+    E, _ = get_encoder_from_schedule(encoder_schedule, "in")
+    if isnothing(E)
+        Σ = cholesky(Symmetric(C + 1e-12I))
+    else
+        Σ = cholesky(Symmetric(Matrix(E) * C * Matrix(E)' + 1e-12 * I))
+    end
+
     return AdvancedMH.RandomWalkProposal(Σ.L * MvNormal(zeros(size(Σ, 1)), I))
 end
 
@@ -599,7 +603,7 @@ function MCMCWrapper(
 }
 
     if length(init_params) == 0
-        init_params = mean(prior)
+        init_params = ndims(prior) > 1 ? mean(prior) : [mean(prior)]
     end
 
     # make into iterable over vectors
@@ -823,26 +827,31 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_lo
     # flatten samples from the chain for manipulation as an array with columns as samples
     red_samples = p_chain[:, :, 1]'
 
-    # Perform a lift back to the full-space, that is aware of the correlation between reduced and null-space variables (through a Gaussian assumption)
-    # Can be done by defining the deterministic Gaussin gain K, to decode, then if the null-space "(I-KE)" is big we also inject noise in the null space
-    C = cov(mcmc.prior)
-    m = reshape(mean(mcmc.prior), :, 1)
     E, b = get_encoder_from_schedule(encoder_schedule, "in") # encoder is affine: E*x + b
-    E = Matrix(E)
-    enc_m = (E * m + b)
-    ECEt = cholesky(Symmetric(E * C * E' + 1e-12 * I))
-    K = C * E' * (ECEt \ I) # Gain
-    # deterministic reconstruction with the Gain (should be similar to decode_data(...))
-    full_samples = m .+ K * (red_samples .- enc_m)
+    if isnothing(E)
+        full_samples = red_samples
+    else
+        # Perform a lift back to the full-space, that is aware of the correlation between reduced and null-space variables (through a Gaussian assumption)
+        # Can be done by defining the deterministic Gaussin gain K, to decode, then if the null-space "(I-KE)" is big we also inject noise in the null space
 
-    projection_loss = tr(C - K * E * C) / tr(C)
-    if projection_loss > boost_for_loss # (default >0.1% of variance is lost in projecting)
-        @info "As the variance lost in reduced space is sufficiently large: $(projection_loss) > boost_for_loss (= $(boost_for_loss)), we inject additional noise into the complement of the reduced space"
-        # Conditionally sample from the null space to preserve correlations with the reduced samples
-        Σ_cond = C - K * E * C
-        L = cholesky(Symmetric(Σ_cond + 1e-12 * I)).L
-        null_samples = L * randn(size(C, 1), size(red_samples, 2))
-        full_samples += null_samples
+        C = cov(mcmc.prior)
+        m = reshape(mean(mcmc.prior), :, 1)
+        E = Matrix(E)
+        enc_m = (E * m + b)
+        ECEt = cholesky(Symmetric(E * C * E' + 1e-12 * I))
+        K = C * E' * (ECEt \ I) # Gain
+        # deterministic reconstruction with the Gain (should be similar to decode_data(...))
+        full_samples = m .+ K * (red_samples .- enc_m)
+
+        projection_loss = tr(C - K * E * C) / tr(C)
+        if projection_loss > boost_for_loss # (default >0.1% of variance is lost in projecting)
+            @info "As the variance lost in reduced space is sufficiently large: $(projection_loss) > boost_for_loss (= $(boost_for_loss)), we inject additional noise into the complement of the reduced space"
+            # Conditionally sample from the null space to preserve correlations with the reduced samples
+            Σ_cond = C - K * E * C
+            L = cholesky(Symmetric(Σ_cond + 1e-12 * I)).L
+            null_samples = L * randn(size(C, 1), size(red_samples, 2))
+            full_samples += null_samples
+        end
     end
 
     p_samples = [Samples(full_samples[slice, :], params_are_columns = true) for slice in p_slices]

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -560,7 +560,11 @@ function MCMCWrapper(
     init_params::AV = [],
     burnin::Int = 0,
     kwargs...,
-) where {AV <: AbstractVector, AMorAV <: Union{AbstractVector, AbstractMatrix}, EorFMW <: Union{Emulator, ForwardMapWrapper}}
+) where {
+    AV <: AbstractVector,
+    AMorAV <: Union{AbstractVector, AbstractMatrix},
+    EorFMW <: Union{Emulator, ForwardMapWrapper},
+}
 
     if length(init_params) == 0
         init_params = mean(prior)

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -263,9 +263,9 @@ Defines the internal log-density function over a vector of observation samples u
 
 Inputs:
 =======
-- θ: Parameters in physical (constrained) coordinates.
-- prior: Prior distribution as a ParameterDistribution
-- em: Emulator object with predict(.) method, evaluations returned in encoded space 
+- θ: Parameters in unconstrained, and encoded coordinates.
+- prior: Prior distribution as a ParameterDistribution (defined on the full, decoded and unconstrained space)
+- em_or_fmw: `Emulator` or `ForwardMapWrapper` object with predict(.) method
 - obs_vec: encoded data vector sample(s)
 """
 function emulator_log_density_model(
@@ -275,14 +275,10 @@ function emulator_log_density_model(
     obs_vec::AV,
 ) where {AV <: AbstractVector, EorFMW <: Union{Emulator, ForwardMapWrapper}}
 
-    # 
-    # transform_to_real = false means g, g_cov, obs_sample are in encoded coords.
-
-    # predict is written to apply to columns.
     # Returned g is a length-1, Vector{Real} or Vector{Vector}, and g_cov is length-1 Vector{Vector} or Vector{Matrix} respectively
     g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode = "in_and_out", add_obs_noise_cov = true)
 
-    decoded_θ = vec(decode_data(em_or_fmw, reshape(θ, :, 1), "in")) # we still compute logpdf(prior, decoded_θ) in full space
+    decoded_θ = vec(decode_data(em_or_fmw, reshape(θ, :, 1), "in")) # we still compute logpdf(prior, decoded_θ) in full space, where prior is defined
 
     if isa(g_cov[1], Real)
         return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(prior, decoded_θ)
@@ -566,9 +562,8 @@ get_encoder_schedule(mcmc::MCMCWrapper) = mcmc.encoder_schedule
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
-Constructor for [`MCMCWrapper`](@ref) which performs the same standardization (SVD 
-decorrelation) that was applied in the Emulator. It creates and wraps an instance of 
-[`EmulatorPosteriorModel`](@ref), for sampling from the Emulator, and 
+Constructor for [`MCMCWrapper`](@ref) that will perform an MCMC sampling in the encoded space given by `em_or_fmw` (`Emulator` or `ForwardMapWrapper`). It creates and wraps an instance of 
+[`EmulatorPosteriorModel`](@ref), for sampling from the Emulator (predicting means and covariances), and 
 [`MetropolisHastingsSampler`](@ref), for generating the MC proposals.
 
 - `mcmc_alg`: [`MCMCProtocol`](@ref) describing the MCMC sampling algorithm to use. Currently
@@ -581,12 +576,11 @@ decorrelation) that was applied in the Emulator. It creates and wraps an instanc
   - [`BarkerSampling`](@ref): Metropolis-Hastings sampling using the Barker
     proposal, which has a robustness to choosing step-size parameters.
 
-- `obs_sample`: Vector (for one sample) or matrix with columns as samples from the observation. Can, e.g., be picked from an Observation struct using `get_obs_sample`.
+- `observation`: Vector (for one sample) or matrix with columns as samples from the observation. Can, e.g., be picked from an `Observation` struct using `get_obs_sample`.
 - `prior`: [`ParameterDistribution`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parameter_distributions/) 
   object containing the parameters' prior distributions.
-- `emulator`: [`Emulator`](@ref) to sample from.
-- `stepsize`: MCMC step size, applied as a scaling to the prior covariance.
-- `init_params`: Starting parameter values for MCMC sampling.
+- `em_or_fmw`: [`Emulator`](@ref) or `ForwardMapWrapper` to sample from.
+- `init_params`: Starting parameter values for MCMC sampling. (defined in unconstrained parameter coordinates)
 - `burnin`: Initial number of MCMC steps to discard from output (pre-convergence).
 """
 function MCMCWrapper(
@@ -808,6 +802,8 @@ optimize_stepsize(mcmc::MCMCWrapper; kwargs...) = optimize_stepsize(Random.GLOBA
 $(TYPEDSIGNATURES)
 
 Lift back the encoded samples into the full space. Similar to using `decode_data`, except that this additionally injects noise from the prior when the encoding is determined to be sufficiently lossy (total lost variance < keyword `boost_for_loss`). This is done in a way that preserves any known correlations between reduced and null-space directions, which is important for posterior reconstruction.
+
+The quantification of correlation depends on Gaussian assumptions, and therefore is approximate. 
 """
 function decode_and_add_noise(
     encoder_schedule::VV,
@@ -850,6 +846,9 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 
 Returns a `ParameterDistribution` object corresponding to the empirical distribution of the 
 samples in `chain`.
+
+keywod args
+- `boost_for_loss`[`=0.001`]: If the encoded space is lossy, and the lost variability due to encoding exceeds a threshold `boost_for_loss`, then in place of decoding posterior samples, additional noise consistent with the prior is injected into the null space of the encoder. See `decode_and_add_noise()` for more detail.  
 
 !!! note
     This method does not currently support combining samples from multiple `Chains`.

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -2,6 +2,8 @@
 module MarkovChainMonteCarlo
 
 using ..Emulators
+import get_encoder_schedule
+
 using ..ParameterDistributions
 using ..EnsembleKalmanProcesses
 
@@ -34,8 +36,9 @@ export EmulatorPosteriorModel,
     optimize_stepsize,
     get_posterior,
     get_sample_kwargs,
+    get_encoder_schedule,
     sample,
-    esjd
+    esjd,
 
 
 # ------------------------------------------------------------------------------------------
@@ -255,7 +258,9 @@ function emulator_log_density_model(
 
     # predict is written to apply to columns.
     # Returned g is a length-1, Vector{Real} or Vector{Vector}, and g_cov is length-1 Vector{Vector} or Vector{Matrix} respectively
-    g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode = "out", add_obs_noise_cov = true)
+    g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode = "in_and_out", add_obs_noise_cov = true)
+
+    decoded_θ = vec(decode_data(em_or_fmw, reshape(θ,:,1), "in")) # to compute logpdf(prior, θ) -> in full space
 
     if isa(g_cov[1], Real)
         return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(prior, θ)
@@ -504,19 +509,21 @@ AbstractMCMC's terminology).
 # Fields
 $(DocStringExtensions.TYPEDFIELDS)
 """
-struct MCMCWrapper{AVV <: AbstractVector, AV <: AbstractVector}
+struct MCMCWrapper{VV1 <: AbstractVector, VV2 <: AbstractVector, VV3<: AbstractVector}
     "[`ParameterDistribution`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parameter_distributions/) object describing the prior distribution on parameter values."
     prior::ParameterDistribution
     "[output_dim x N_samples] matrix, of given observation data."
-    observations::AVV
+    observations::VV1
     "Vector of observations describing the data samples to actually used during MCMC sampling (that have been transformed into a space consistent with emulator outputs)."
-    encoded_observations::AV
+    encoded_observations::VV2
     "`AdvancedMH.DensityModel` object, used to evaluate the posterior density being sampled from."
     log_posterior_map::AbstractMCMC.AbstractModel
     "Object describing a MCMC sampling algorithm and its settings."
     mh_proposal_sampler::AbstractMCMC.AbstractSampler
     "NamedTuple of other arguments to be passed to `AbstractMCMC.sample()`."
     sample_kwargs::NamedTuple
+    "Vector of encoders dictating how to encode/decode data."
+    encoder_schedule::VV3
 end
 
 """
@@ -525,6 +532,14 @@ $(TYPEDSIGNATURES)
 gets the NameTuple of keywords that are passed into the Sampler algorithm
 """
 get_sample_kwargs(mcmc::MCMCWrapper) = mcmc.sample_kwargs
+
+"""
+$(TYPEDSIGNATURES)
+
+gets the stored `encoder_schedule` from an `MCMCWrapper`
+"""
+get_encoder_schedule(mcmc::MCMCWrapper) = mcmc.encoder_schedule
+
 
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
@@ -577,33 +592,29 @@ function MCMCWrapper(
         eachcol(observation)
     end
 
+    # encoding, saved in MCMCWrapper
+    encoder_schedule= get_encoder_schedule(em_or_fmw)
+    
     # encoding data works on columns but mcmc wants vec-of-vec
-    encoded_obs = [vec(encode_data(em_or_fmw, reshape(obs, :, 1), "out")) for obs in obs_slice]
+    encoded_obs = [vec(encode_data(encoder_schedule, reshape(obs, :, 1), "out")) for obs in obs_slice]
     # encoding initial condition
-    #encoded_init_params = vec(encode_data(em_or_fmw, reshape(init_params,:,1), "in"))
-
+    encoded_init_params = vec(encode_data(encoder_schedule, reshape(init_params,:,1), "in"))
+    
     log_posterior_map = EmulatorPosteriorModel(prior, em_or_fmw, encoded_obs)
     mh_proposal_sampler = MetropolisHastingsSampler(mcmc_alg, prior)
 
-    # parameter names are needed in every dimension in a MCMCChains object needed for diagnostics
-    # so create the duplicates here
-    dd = get_dimensions(prior)
-    if all(dd .== 1) # i.e if dd == [1, 1, 1, 1, 1], => all params are univariate
-        param_names = get_name(prior)
-    else # else use multiplicity to get still informative parameter names
-        pn = get_name(prior)
-        param_names = reduce(vcat, [(pn[k] * "_") .* map(x -> string(x), 1:dd[k]) for k in 1:length(pn)])
-    end
-
-    sample_kwargs = (; # set defaults here
-        #        :initial_params => deepcopy(encoded_init_params),
-        :initial_params => deepcopy(init_params),
+    # naming encoded dimensions
+    param_names = ["encoded_param_$(k)" for k in 1:size(encoded_init_params,1)]
+    
+    sample_kwargs = (
+        ; # set defaults here
+        :initial_params => deepcopy(encoded_init_params),
         :param_names => param_names,
         :discard_initial => burnin,
         :chain_type => MCMCChains.Chains,
     )
     sample_kwargs = merge(sample_kwargs, kwargs) # override defaults with any explicit values
-    return MCMCWrapper(prior, obs_slice, encoded_obs, log_posterior_map, mh_proposal_sampler, sample_kwargs)
+    return MCMCWrapper(prior, obs_slice, encoded_obs, log_posterior_map, mh_proposal_sampler, sample_kwargs, encoder_schedule)
 end
 
 function MCMCWrapper(
@@ -778,11 +789,13 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
     p_slices = batch(mcmc.prior)
     flat_constraints = get_all_constraints(mcmc.prior)
 
+    
     # Cast data in chain to a ParameterDistribution object. Data layout in Chain is an
     # (N_samples x n_params x n_chains) AxisArray, so samples are in rows.
     p_chain = Array(Chains(chain, :parameters)) # discard internal/diagnostic data
-    p_samples = [Samples(p_chain[:, slice, 1], params_are_columns = false) for slice in p_slices]
-
+    # get the encoding schedule for decoding
+    encoder_schedule = get_encoder_schedule(mcmc)
+    p_samples = [Samples(decode_data(encoder_schedule, p_chain[:, slice, 1], "in"), params_are_columns = false) for slice in p_slices]
 
     # live in same space as prior
     # checks if a function distribution, by looking at if the distribution is nested

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -2,6 +2,8 @@
 module MarkovChainMonteCarlo
 
 using ..Emulators
+import ..Emulators: get_encoder_schedule
+using ..Utilities
 
 using ..ParameterDistributions
 using ..EnsembleKalmanProcesses
@@ -259,12 +261,12 @@ function emulator_log_density_model(
     # Returned g is a length-1, Vector{Real} or Vector{Vector}, and g_cov is length-1 Vector{Vector} or Vector{Matrix} respectively
     g, g_cov = Emulators.predict(em_or_fmw, reshape(θ, :, 1), encode = "in_and_out", add_obs_noise_cov = true)
 
-    decoded_θ = vec(decode_data(em_or_fmw, reshape(θ, :, 1), "in")) # to compute logpdf(prior, θ) -> in full space
+    decoded_θ = vec(decode_data(em_or_fmw, reshape(θ, :, 1), "in")) # we still compute logpdf(prior, decoded_θ) in full space
 
     if isa(g_cov[1], Real)
-        return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(prior, θ)
+        return sum([logpdf(MvNormal(obs, g_cov[1] * I), vec(g)) for obs in obs_vec]) + logpdf(prior, decoded_θ)
     else
-        return sum([logpdf(MvNormal(obs, g_cov[1]), vec(g)) for obs in obs_vec]) + logpdf(prior, θ)
+        return sum([logpdf(MvNormal(obs, g_cov[1]), vec(g)) for obs in obs_vec]) + logpdf(prior, decoded_θ)
     end
 
 end
@@ -802,26 +804,29 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains)
 
     # get the encoding schedule for decoding
     encoder_schedule = get_encoder_schedule(mcmc)
-    # [1] sample randomly from the null space of the encoding and add in
-#    dec_samples = Matrix(decode_data(encoder_schedule, p_chain[:, slice, 1], "in"))
-#    prior_samples = sample(mcmc.prior, size(decoded_inputs, 2))
-#    null_samples =
-#        prior_samples - Matrix(decode_data(encoder_schedule, encode_data(encoder_schedule, prior_samples, "in"), "in"))
-#    dec_samples .+= null_samples
-#    p_samples = [Samples(dec_samples, params_are_columns = false) for slice in p_slices]
+    
+    # [for testing - just decode]
+    to_be_dec_samples = reduce(vcat, [p_chain[:, slice, 1]' for slice in p_slices])
+    dec_samples = decode_data(encoder_schedule, to_be_dec_samples, "in")
+    p_samples = [Samples(dec_samples[slice,:], params_are_columns = true) for slice in p_slices]
 
-    # [2] conditionally sample from the null space to preserve correlations with the reduced samples
-    red_samples = p_chain[:, slice, 1]
+    
+    # Conditionally sample from the null space to preserve correlations with the reduced samples
+
+    #=
+    red_samples = reduce(vcat, [p_chain[:, slice, 1]' for slice in p_slices])
     C = cov(mcmc.prior)
-    E = encode_data(encoder_schedule, ones(ndims(prior)), "in")
+    E = Matrix(get_encoder_from_schedule(encoder_schedule, "in"))
+
     ECEt = cholesky(Symmetric(E * C * E'))
-    K = C * E' * inv(ECEt) # Kalman Gain
+    K = C * E' * inv(ECEt) # Kalman Gain    
+    
     # then compute μ + K(z-Eμ) + (I-KE)η
     sn_samples = randn(size(red_samples))
-    full_samples = mean(prior) .+ K*(red_samples .- E*mean(prior)) + (I-K*E)*sn_samples
+    full_samples = mean(mcmc.prior) .+ K*(red_samples .- E*mean(mcmc.prior)) + (I-K*E)*sn_samples
     
-    p_samples = [Samples(full_samples, params_are_columns = false) for slice in p_slices]
-
+    p_samples = [Samples(full_samples[slice,:], params_are_columns = true) for slice in p_slices]
+    =#
      
     # live in same space as prior
     # checks if a function distribution, by looking at if the distribution is nested

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -818,12 +818,18 @@ Returns a `ParameterDistribution` object corresponding to the empirical distribu
 samples in `chain`.
 
 keywod args
-- `boost_for_loss`[`=0.001`]: If the encoded space is lossy, and the lost variability due to encoding exceeds a threshold `boost_for_loss`, then in place of decoding posterior samples, additional noise consistent with the prior is injected into the null space of the encoder. See `decode_and_add_noise()` for more detail.  
+- `noise_injector_threshold`[`=0.001`]: If the encoded space is lossy, and the lost variability due to encoding exceeds a threshold `noise_injector_threshold`, then in place of decoding posterior samples, additional noise consistent with the prior is injected into the null space of the encoder. See `decode_and_add_noise()` for more detail.  
+- `noise_injector_scaling`[`=1.0`]: Scales the injected noise; though 1.0 is the only "consistent" value, reduction may be necessary if noise injection causes posterior samples to be unstable in simulations.
 
 !!! note
     This method does not currently support combining samples from multiple `Chains`.
 """
-function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_loss = 0.001)
+function get_posterior(
+    mcmc::MCMCWrapper,
+    chain::MCMCChains.Chains;
+    noise_injector_threshold::FT = 0.001,
+    noise_injector_scaling::FT = 1.0,
+) where {FT <: Real}
     p_names = get_name(mcmc.prior)
     p_slices = batch(mcmc.prior)
     flat_constraints = get_all_constraints(mcmc.prior)
@@ -837,7 +843,13 @@ function get_posterior(mcmc::MCMCWrapper, chain::MCMCChains.Chains; boost_for_lo
 
     # flatten samples from the chain for manipulation as an array with columns as samples
     red_samples = p_chain[:, :, 1]'
-    full_samples = decode_and_add_noise(encoder_schedule, red_samples, mcmc.prior, boost_for_loss)
+    full_samples = decode_and_add_noise(
+        encoder_schedule,
+        red_samples,
+        mcmc.prior,
+        noise_injector_threshold,
+        noise_injector_scaling,
+    )
 
     p_samples = [Samples(full_samples[slice, :], params_are_columns = true) for slice in p_slices]
 

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -817,7 +817,7 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 Returns a `ParameterDistribution` object corresponding to the empirical distribution of the 
 samples in `chain`.
 
-keywod args
+keyword args
 - `noise_injector_threshold`[`=0.001`]: If the encoded space is lossy, and the lost variability due to encoding exceeds a threshold `noise_injector_threshold`, then in place of decoding posterior samples, additional noise consistent with the prior is injected into the null space of the encoder. See `decode_and_add_noise()` for more detail.  
 - `noise_injector_scaling`[`=1.0`]: Scales the injected noise; though 1.0 is the only "consistent" value, reduction may be necessary if noise injection causes posterior samples to be unstable in simulations.
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -748,8 +748,7 @@ function get_encoder_from_schedule(
         if in_or_out ∉ ["in", "out"]
             bad_in_or_out(in_or_out)
         end
-        @info encoder_schedule
-
+        
         encoder_mats =
             [get_encoder_mat(processor)[1] for (processor, apply_to) in encoder_schedule if apply_to == in_or_out]
         @info encoder_mats
@@ -760,7 +759,7 @@ function get_encoder_from_schedule(
             linear_part = prod(encoder_mats)
 
             # rather than extracting the shifts etc. we can get this by just applying it to zero
-            constant_part = encode_data(encoder_schedule, zeros(size(linear_part, 1), 1), "in")
+            constant_part = encode_data(encoder_schedule, zeros(size(linear_part, 1), 1), in_or_out)
 
             return linear_part, constant_part
         end
@@ -768,10 +767,11 @@ function get_encoder_from_schedule(
 end
 
 function get_encoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
-    return [
-        (get_encoder_from_schedule(encoder_schedule, "in"), "in")
-        (get_encoder_from_schedule(encoder_schedule, "out"), "out")
-    ]
+    return Dict(
+        "in" => get_encoder_from_schedule(encoder_schedule, "in"),
+        "out" => get_encoder_from_schedule(encoder_schedule, "out"),
+    )
+    
 end
 
 
@@ -801,7 +801,7 @@ function get_decoder_from_schedule(
             linear_part = prod(decoder_mats)
 
             # rather than extracting the shifts etc. we can get this by just applying it to zero
-            constant_part = decode_data(encoder_schedule, zeros(size(linear_part, 1), 1), "in")
+            constant_part = decode_data(encoder_schedule, zeros(size(linear_part, 1), 1), in_or_out)
 
             return linear_part, constant_part
         end
@@ -809,10 +809,10 @@ function get_decoder_from_schedule(
 end
 
 function get_decoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
-    return [
-        (get_decoder_from_schedule(encoder_schedule, "in"), "in")
-        (get_decoder_from_schedule(encoder_schedule, "out"), "out")
-    ]
+    return Dict(
+        "in" => get_decoder_from_schedule(encoder_schedule, "in"),
+        "out" => get_decoder_from_schedule(encoder_schedule, "out"),
+    )
 end
 
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -867,9 +867,9 @@ struct NoiseInjector{
     L::NorMM
     "Scale the noise (may be needed (<1.0) for robustness if samples will be run in a physical model)"
     scaling::FT
-    "whether to use the encoding or not"
+    "whether to use the noise injection or not"
     use_noise::Bool
-    "the encoding that was used to construct this"
+    "the encoding that was used to construct this object"
     encoder_schedule::VV
 end
 
@@ -934,13 +934,15 @@ function decode_and_add_noise(
         return samples
     end
 
-    K, enc_m, m, L, scaling, use_noise, encoder_schedule = noise_injector.K,
-    noise_injector.enc_m,
-    noise_injector.m,
-    noise_injector.L,
-    noise_injector.scaling,
-    noise_injector.use_noise,
-    noise_injector.encoder_schedule
+    (K, enc_m, m, L, scaling, use_noise, encoder_schedule) = (
+        noise_injector.K,
+        noise_injector.enc_m,
+        noise_injector.m,
+        noise_injector.L,
+        noise_injector.scaling,
+        noise_injector.use_noise,
+        noise_injector.encoder_schedule,
+    )
 
     if use_noise
         recovered_samples = m .+ K * (samples .- enc_m)

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -736,30 +736,36 @@ function bad_in_or_out(in_or_out::AS) where {AS <: AbstractString}
 end
 
 # get affine encoder from schedule
-function get_encoder_from_schedule(encoder_schedule::VV, in_or_out::AS) where {VV <: AbstractVector, AS <: AbstractString}
+function get_encoder_from_schedule(
+    encoder_schedule::VV,
+    in_or_out::AS,
+) where {VV <: AbstractVector, AS <: AbstractString}
     if in_or_out ∉ ["in", "out"]
         bad_in_or_out(in_or_out)
     end
-    
-    encoder_mats = [get_encoder_mat(processor)[1]
-        for (processor, apply_to) in encoder_schedule if apply_to == in_or_out ]
+
+    encoder_mats =
+        [get_encoder_mat(processor)[1] for (processor, apply_to) in encoder_schedule if apply_to == in_or_out]
     linear_part = prod(encoder_mats)
 
     # rather than extracting the shifts etc. we can get this by just applying it to zero
-    constant_part = encode_data(encoder_schedule,zeros(size(linear_part,1),1), "in")    
-    
+    constant_part = encode_data(encoder_schedule, zeros(size(linear_part, 1), 1), "in")
+
     return linear_part, constant_part
 end
 
 function get_encoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
     return [
-    (get_encoder_from_schedule(encoder_schedule, "in"),"in")
-    (get_encoder_from_schedule(encoder_schedule, "out"),"out")
+        (get_encoder_from_schedule(encoder_schedule, "in"), "in")
+        (get_encoder_from_schedule(encoder_schedule, "out"), "out")
     ]
 end
 
 
-function get_decoder_from_schedule(encoder_schedule::VV, in_or_out::AS) where {VV <: AbstractVector, AS <: AbstractString}
+function get_decoder_from_schedule(
+    encoder_schedule::VV,
+    in_or_out::AS,
+) where {VV <: AbstractVector, AS <: AbstractString}
     if in_or_out ∉ ["in", "out"]
         bad_in_or_out(in_or_out)
     end
@@ -773,15 +779,15 @@ function get_decoder_from_schedule(encoder_schedule::VV, in_or_out::AS) where {V
     linear_part = prod(decoder_mats)
 
     # rather than extracting the shifts etc. we can get this by just applying it to zero
-    constant_part = decode_data(encoder_schedule, zeros(size(linear_part,1),1), "in")    
+    constant_part = decode_data(encoder_schedule, zeros(size(linear_part, 1), 1), "in")
 
     return linear_part, constant_part
 end
 
 function get_decoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
     return [
-    (get_decoder_from_schedule(encoder_schedule, "in"), "in")
-    (get_decoder_from_schedule(encoder_schedule, "out"), "out")
+        (get_decoder_from_schedule(encoder_schedule, "in"), "in")
+        (get_decoder_from_schedule(encoder_schedule, "out"), "out")
     ]
 end
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -736,6 +736,13 @@ function bad_in_or_out(in_or_out::AS) where {AS <: AbstractString}
 end
 
 # get affine encoder from schedule
+"""
+$(TYPEDSIGNATURES)
+
+Affine encodings can be represented as `Ex + b`. This function returns `E,b`. `E` will be represented as a `LinearMap` object (can apply `E = Matrix(E)` to rebuild).
+
+- `in_or_out`: should be either `"in"` or `"out"`, to retrieve either the `input` or `output` encoder
+"""
 function get_encoder_from_schedule(
     encoder_schedule::VV,
     in_or_out::AS,
@@ -765,6 +772,11 @@ function get_encoder_from_schedule(
     end
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Affine encodings can be represented as `Ex + b`. This function returns `E,b` for the input and output encoders in a `Dict` indexed by `"in"` and `"out"`. `E` will be represented as a `LinearMap` object (can apply `E = Matrix(E)` to rebuild).
+"""
 function get_encoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
     return Dict(
         "in" => get_encoder_from_schedule(encoder_schedule, "in"),
@@ -773,7 +785,13 @@ function get_encoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVe
 
 end
 
+"""
+$(TYPEDSIGNATURES)
 
+Affine decodings can be represented as `Dx + b`. This function returns `D,b`. `D` will be represented as a `LinearMap` object (can apply `D = Matrix(D)` to rebuild).
+
+- `in_or_out`: should be either `"in"` or `"out"`, to retrieve either the `input` or `output` encoder
+"""
 function get_decoder_from_schedule(
     encoder_schedule::VV,
     in_or_out::AS,
@@ -807,6 +825,11 @@ function get_decoder_from_schedule(
     end
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Affine decodings can be represented as `Dx + b`. This function returns `D,b` for the input and output encoders in a `Dict` indexed by `"in"` and `"out"`. `D` will be represented as a `LinearMap` object (can apply `D = Matrix(D)` to rebuild).
+"""
 function get_decoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
     return Dict(
         "in" => get_decoder_from_schedule(encoder_schedule, "in"),

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -735,16 +735,20 @@ function bad_in_or_out(in_or_out::AS) where {AS <: AbstractString}
     )
 end
 
-# get encoder from schedule
+# get affine encoder from schedule
 function get_encoder_from_schedule(encoder_schedule::VV, in_or_out::AS) where {VV <: AbstractVector, AS <: AbstractString}
     if in_or_out ∉ ["in", "out"]
         bad_in_or_out(in_or_out)
     end
     
-    return prod(
-        get_encoder_mat(processor)[1]
-        for (processor, apply_to) in encoder_schedule if apply_to == in_or_out ) 
-            
+    encoder_mats = [get_encoder_mat(processor)[1]
+        for (processor, apply_to) in encoder_schedule if apply_to == in_or_out ]
+    linear_part = prod(encoder_mats)
+
+    # rather than extracting the shifts etc. we can get this by just applying it to zero
+    constant_part = encode_data(encoder_schedule,zeros(size(linear_part,1),1), "in")    
+    
+    return linear_part, constant_part
 end
 
 function get_encoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
@@ -766,8 +770,12 @@ function get_decoder_from_schedule(encoder_schedule::VV, in_or_out::AS) where {V
             push!(decoder_mats, get_decoder_mat(processor)[1])
         end
     end
-                  
-    return prod(decoder_mats)
+    linear_part = prod(decoder_mats)
+
+    # rather than extracting the shifts etc. we can get this by just applying it to zero
+    constant_part = decode_data(encoder_schedule, zeros(size(linear_part,1),1), "in")    
+
+    return linear_part, constant_part
 end
 
 function get_decoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -30,7 +30,9 @@ export create_encoder_schedule,
     norm,
     norm_linear_map,
     isequal_linear,
-    encoder_kwargs_from
+    encoder_kwargs_from,
+    get_encoder_from_schedule,
+    get_decoder_from_schedule
 
 
 const StructureMatrix = Union{UniformScaling, AbstractMatrix, AbstractVector, LinearMap} # The vector appears due to possible block-structured matrices (build=false)
@@ -731,6 +733,48 @@ function bad_in_or_out(in_or_out::AS) where {AS <: AbstractString}
             "`in_or_out` must be either \"in\" (data is an input) or \"out\" (data is an output). Received $(in_or_out)",
         ),
     )
+end
+
+# get encoder from schedule
+function get_encoder_from_schedule(encoder_schedule::VV, in_or_out::AS) where {VV <: AbstractVector, AS <: AbstractString}
+    if in_or_out ∉ ["in", "out"]
+        bad_in_or_out(in_or_out)
+    end
+    
+    return prod(
+        get_encoder_mat(processor)[1]
+        for (processor, apply_to) in encoder_schedule if apply_to == in_or_out ) 
+            
+end
+
+function get_encoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
+    return [
+    (get_encoder_from_schedule(encoder_schedule, "in"),"in")
+    (get_encoder_from_schedule(encoder_schedule, "out"),"out")
+    ]
+end
+
+
+function get_decoder_from_schedule(encoder_schedule::VV, in_or_out::AS) where {VV <: AbstractVector, AS <: AbstractString}
+    if in_or_out ∉ ["in", "out"]
+        bad_in_or_out(in_or_out)
+    end
+    decoder_mats = []
+    for idx in reverse(eachindex(encoder_schedule))
+        (processor, apply_to) = encoder_schedule[idx]
+        if apply_to == in_or_out
+            push!(decoder_mats, get_decoder_mat(processor)[1])
+        end
+    end
+                  
+    return prod(decoder_mats)
+end
+
+function get_decoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
+    return [
+    (get_decoder_from_schedule(encoder_schedule, "in"), "in")
+    (get_decoder_from_schedule(encoder_schedule, "out"), "out")
+    ]
 end
 
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -740,18 +740,31 @@ function get_encoder_from_schedule(
     encoder_schedule::VV,
     in_or_out::AS,
 ) where {VV <: AbstractVector, AS <: AbstractString}
-    if in_or_out ∉ ["in", "out"]
-        bad_in_or_out(in_or_out)
+
+    # if no encoding
+    if length(encoder_schedule) == 0
+        return nothing, nothing
+    else
+        if in_or_out ∉ ["in", "out"]
+            bad_in_or_out(in_or_out)
+        end
+        @info encoder_schedule
+
+        encoder_mats =
+            [get_encoder_mat(processor)[1] for (processor, apply_to) in encoder_schedule if apply_to == in_or_out]
+        @info encoder_mats
+
+        if length(encoder_mats) == 0
+            return nothing, nothing
+        else
+            linear_part = prod(encoder_mats)
+
+            # rather than extracting the shifts etc. we can get this by just applying it to zero
+            constant_part = encode_data(encoder_schedule, zeros(size(linear_part, 1), 1), "in")
+
+            return linear_part, constant_part
+        end
     end
-
-    encoder_mats =
-        [get_encoder_mat(processor)[1] for (processor, apply_to) in encoder_schedule if apply_to == in_or_out]
-    linear_part = prod(encoder_mats)
-
-    # rather than extracting the shifts etc. we can get this by just applying it to zero
-    constant_part = encode_data(encoder_schedule, zeros(size(linear_part, 1), 1), "in")
-
-    return linear_part, constant_part
 end
 
 function get_encoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}
@@ -766,22 +779,33 @@ function get_decoder_from_schedule(
     encoder_schedule::VV,
     in_or_out::AS,
 ) where {VV <: AbstractVector, AS <: AbstractString}
-    if in_or_out ∉ ["in", "out"]
-        bad_in_or_out(in_or_out)
-    end
-    decoder_mats = []
-    for idx in reverse(eachindex(encoder_schedule))
-        (processor, apply_to) = encoder_schedule[idx]
-        if apply_to == in_or_out
-            push!(decoder_mats, get_decoder_mat(processor)[1])
+    # if no encoding
+    if length(encoder_schedule) == 0
+        return nothing, nothing
+    else
+
+        if in_or_out ∉ ["in", "out"]
+            bad_in_or_out(in_or_out)
+        end
+        decoder_mats = []
+        for idx in reverse(eachindex(encoder_schedule))
+            (processor, apply_to) = encoder_schedule[idx]
+            if apply_to == in_or_out
+                push!(decoder_mats, get_decoder_mat(processor)[1])
+            end
+        end
+
+        if length(encoder_mats) == 0
+            return nothing, nothing
+        else
+            linear_part = prod(decoder_mats)
+
+            # rather than extracting the shifts etc. we can get this by just applying it to zero
+            constant_part = decode_data(encoder_schedule, zeros(size(linear_part, 1), 1), "in")
+
+            return linear_part, constant_part
         end
     end
-    linear_part = prod(decoder_mats)
-
-    # rather than extracting the shifts etc. we can get this by just applying it to zero
-    constant_part = decode_data(encoder_schedule, zeros(size(linear_part, 1), 1), "in")
-
-    return linear_part, constant_part
 end
 
 function get_decoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVector}

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -34,7 +34,8 @@ export create_encoder_schedule,
     get_encoder_from_schedule,
     get_decoder_from_schedule,
     NoiseInjector,
-    decode_and_add_noise
+    decode_and_add_noise,
+    create_noise_injector
 
 
 const StructureMatrix = Union{UniformScaling, AbstractMatrix, AbstractVector, LinearMap} # The vector appears due to possible block-structured matrices (build=false)
@@ -841,7 +842,13 @@ function get_decoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVe
 end
 
 ## Decoding and add noise:
+"""
+$(TYPEDEF)
 
+Structure used to store precomputed quantities for `decode_and_add_noise(...)`, build with `create_noise_injector(...)`
+
+$(TYPEDFIELDS)
+"""
 struct NoiseInjector{
     MM1 <: AbstractMatrix,
     MM2 <: AbstractMatrix,
@@ -869,10 +876,9 @@ $(TYPEDSIGNATURES)
 
 Returns either a `NoiseInjector` object that stores precomputed quantities used in `decode_and_add_noise(...)`, or returns `nothing`. The condition to return nothing:
 1. If the encoder is effectively lossless, as determined by it's variance loss not exceeding threshold `boost_for_loss`
-2. If the encoder_schedule is empty
-
+2. If the encoder_schedule is empty 
 """
-function make_noise_injector(
+function create_noise_injector(
     encoder_schedule::VV,
     prior::PD,
     boost_for_loss::FT,
@@ -945,7 +951,7 @@ function decode_and_add_noise(
     prior::PD,
     boost_for_loss::FT,
 ) where {MM <: AbstractMatrix, PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
-    noise_injector = make_noise_injector(encoder_schedule, prior, boost_for_loss)
+    noise_injector = create_noise_injector(encoder_schedule, prior, boost_for_loss)
     return decode_and_add_noise(noise_injector, samples)
 end
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -32,7 +32,9 @@ export create_encoder_schedule,
     isequal_linear,
     encoder_kwargs_from,
     get_encoder_from_schedule,
-    get_decoder_from_schedule
+    get_decoder_from_schedule,
+    NoiseInjector,
+    decode_and_add_noise
 
 
 const StructureMatrix = Union{UniformScaling, AbstractMatrix, AbstractVector, LinearMap} # The vector appears due to possible block-structured matrices (build=false)
@@ -762,8 +764,8 @@ function get_encoder_from_schedule(
         if length(encoder_mats) == 0
             return nothing, nothing
         else
-            linear_part = prod(encoder_mats)
-
+            # Note, the action of encoders (E_1,E_2,E_3) is the product x -> (E_3*E_2*E_1)*x so must be reversed. `prod` unsafe here
+            linear_part = reduce(*, reverse(encoder_mats))
             # rather than extracting the shifts etc. we can get this by just applying it to zero
             constant_part = encode_data(encoder_schedule, zeros(size(linear_part, 2), 1), in_or_out)
 
@@ -815,7 +817,8 @@ function get_decoder_from_schedule(
         if length(decoder_mats) == 0
             return nothing, nothing
         else
-            linear_part = prod(decoder_mats)
+            # Note, the action of decoders (D_1,D_2,D_3) is the product x -> (D_3*D_2*D_1)*x so must be reversed (again)
+            linear_part = reduce(*, reverse(decoder_mats))
 
             # rather than extracting the shifts etc. we can get this by just applying it to zero
             constant_part = decode_data(encoder_schedule, zeros(size(linear_part, 2), 1), in_or_out)
@@ -837,6 +840,114 @@ function get_decoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVe
     )
 end
 
+## Decoding and add noise:
+
+struct NoiseInjector{
+    MM1 <: AbstractMatrix,
+    MM2 <: AbstractMatrix,
+    MM3 <: AbstractMatrix,
+    VV <: AbstractVector,
+    NorMM <: Union{Nothing, AbstractMatrix},
+}
+    "Gain Matrix from encoded to decoded space"
+    K::MM1
+    "encoded prior mean"
+    enc_m::MM2
+    "prior mean"
+    m::MM3
+    "cholesky factor of encoded prior covariance"
+    L::NorMM
+    "whether to use the encoding or not"
+    use_noise::Bool
+    "the encoding that was used to construct this"
+    encoder_schedule::VV
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Returns either a `NoiseInjector` object that stores precomputed quantities used in `decode_and_add_noise(...)`, or returns `nothing`. The condition to return nothing:
+1. If the encoder is effectively lossless, as determined by it's variance loss not exceeding threshold `boost_for_loss`
+2. If the encoder_schedule is empty
+
+"""
+function make_noise_injector(
+    encoder_schedule::VV,
+    prior::PD,
+    boost_for_loss::FT,
+) where {PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
+
+    E, b = get_encoder_from_schedule(encoder_schedule, "in")
+    if isnothing(E)
+        return nothing
+    end
+
+    C = cov(prior)
+    m = reshape(mean(prior), :, 1)
+    E = Matrix(E)
+
+    enc_m = E * m + b
+
+    # Precompute gain
+    ECEt = cholesky(Symmetric(E * C * E' + 1e-12 * I))
+    K = C * E' * (ECEt \ I)
+
+    Σ_cond = C - K * E * C
+    projection_loss = tr(Σ_cond) / tr(C)
+
+    if projection_loss > boost_for_loss
+        @info "Injecting nullspace noise: $(projection_loss) > $(boost_for_loss)"
+        L = cholesky(Symmetric(Σ_cond + 1e-12 * I)).L
+        use_noise = true
+    else
+        L = nothing
+        use_noise = false
+    end
+
+    return NoiseInjector(K, enc_m, m, L, use_noise, encoder_schedule)
+end
+
+function decode_and_add_noise(
+    noise_injector::NorNI,
+    samples::MM,
+) where {NorNI <: Union{Nothing, NoiseInjector}, MM <: AbstractMatrix}
+    if isnothing(noise_injector)
+        return samples
+    end
+
+    K, enc_m, m, L, use_noise, encoder_schedule = noise_injector.K,
+    noise_injector.enc_m,
+    noise_injector.m,
+    noise_injector.L,
+    noise_injector.use_noise,
+    noise_injector.encoder_schedule
+    if use_noise
+        recovered_samples = m .+ K * (samples .- enc_m)
+
+        null_samples = L * randn(size(L, 1), size(samples, 2))
+        return recovered_samples + null_samples
+    else
+        return decode_data(encoder_schedule, samples, "in")
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Lift back the encoded samples into the full space. Similar to using `decode_data`, except that this additionally injects noise from the prior when the encoding is determined to be sufficiently lossy (total lost variance < keyword `boost_for_loss`). This is done in a way that preserves any known correlations between reduced and null-space directions, which is important for posterior reconstruction.
+
+The quantification of correlation depends on Gaussian assumptions, and therefore is approximate. 
+"""
+function decode_and_add_noise(
+    encoder_schedule::VV,
+    samples::MM,
+    prior::PD,
+    boost_for_loss::FT,
+) where {MM <: AbstractMatrix, PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
+    noise_injector = make_noise_injector(encoder_schedule, prior, boost_for_loss)
+    return decode_and_add_noise(noise_injector, samples)
+end
 
 # Processors
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -751,7 +751,6 @@ function get_encoder_from_schedule(
         
         encoder_mats =
             [get_encoder_mat(processor)[1] for (processor, apply_to) in encoder_schedule if apply_to == in_or_out]
-        @info encoder_mats
 
         if length(encoder_mats) == 0
             return nothing, nothing
@@ -759,7 +758,7 @@ function get_encoder_from_schedule(
             linear_part = prod(encoder_mats)
 
             # rather than extracting the shifts etc. we can get this by just applying it to zero
-            constant_part = encode_data(encoder_schedule, zeros(size(linear_part, 1), 1), in_or_out)
+            constant_part = encode_data(encoder_schedule, zeros(size(linear_part, 2), 1), in_or_out)
 
             return linear_part, constant_part
         end
@@ -795,13 +794,13 @@ function get_decoder_from_schedule(
             end
         end
 
-        if length(encoder_mats) == 0
+        if length(decoder_mats) == 0
             return nothing, nothing
         else
             linear_part = prod(decoder_mats)
 
             # rather than extracting the shifts etc. we can get this by just applying it to zero
-            constant_part = decode_data(encoder_schedule, zeros(size(linear_part, 1), 1), in_or_out)
+            constant_part = decode_data(encoder_schedule, zeros(size(linear_part, 2), 1), in_or_out)
 
             return linear_part, constant_part
         end

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -748,7 +748,7 @@ function get_encoder_from_schedule(
         if in_or_out ∉ ["in", "out"]
             bad_in_or_out(in_or_out)
         end
-        
+
         encoder_mats =
             [get_encoder_mat(processor)[1] for (processor, apply_to) in encoder_schedule if apply_to == in_or_out]
 
@@ -770,7 +770,7 @@ function get_encoder_from_schedule(encoder_schedule::VV) where {VV <: AbstractVe
         "in" => get_encoder_from_schedule(encoder_schedule, "in"),
         "out" => get_encoder_from_schedule(encoder_schedule, "out"),
     )
-    
+
 end
 
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -855,6 +855,7 @@ struct NoiseInjector{
     MM3 <: AbstractMatrix,
     VV <: AbstractVector,
     NorMM <: Union{Nothing, AbstractMatrix},
+    FT <: Real,
 }
     "Gain Matrix from encoded to decoded space"
     K::MM1
@@ -864,6 +865,8 @@ struct NoiseInjector{
     m::MM3
     "cholesky factor of encoded prior covariance"
     L::NorMM
+    "Scale the noise (may be needed (<1.0) for robustness if samples will be run in a physical model)"
+    scaling::FT
     "whether to use the encoding or not"
     use_noise::Bool
     "the encoding that was used to construct this"
@@ -875,13 +878,15 @@ end
 $(TYPEDSIGNATURES)
 
 Returns either a `NoiseInjector` object that stores precomputed quantities used in `decode_and_add_noise(...)`, or returns `nothing`. The condition to return nothing:
-1. If the encoder is effectively lossless, as determined by it's variance loss not exceeding threshold `boost_for_loss`
-2. If the encoder_schedule is empty 
+1. If the encoder is effectively lossless, as determined by it's variance loss not exceeding threshold `noise_injector_threshold`
+2. If the encoder_schedule is empty
+One can additionally scale the injected samples with `noise_injector_scaling`
 """
 function create_noise_injector(
     encoder_schedule::VV,
     prior::PD,
-    boost_for_loss::FT,
+    noise_injector_threshold::FT,
+    noise_injector_scaling::FT,
 ) where {PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
 
     E, b = get_encoder_from_schedule(encoder_schedule, "in")
@@ -902,8 +907,8 @@ function create_noise_injector(
     Σ_cond = C - K * E * C
     projection_loss = tr(Σ_cond) / tr(C)
 
-    if projection_loss > boost_for_loss
-        @info "Injecting nullspace noise: $(projection_loss) > $(boost_for_loss)"
+    if projection_loss > noise_injector_threshold
+        @info "Injecting nullspace noise: $(projection_loss) > $(noise_injector_threshold)"
         L = cholesky(Symmetric(Σ_cond + 1e-12 * I)).L
         use_noise = true
     else
@@ -911,7 +916,14 @@ function create_noise_injector(
         use_noise = false
     end
 
-    return NoiseInjector(K, enc_m, m, L, use_noise, encoder_schedule)
+    if noise_injector_scaling < 0.0
+        scaling = abs(noise_injector_scaling) + eps()
+        @warn "`noise_injector_scaling` must be positive, received $(noise_injector_scaling). Continuing with scaling= $(scaling)..."
+    else
+        scaling = noise_injector_scaling
+    end
+
+    return NoiseInjector(K, enc_m, m, L, scaling, use_noise, encoder_schedule)
 end
 
 function decode_and_add_noise(
@@ -922,16 +934,18 @@ function decode_and_add_noise(
         return samples
     end
 
-    K, enc_m, m, L, use_noise, encoder_schedule = noise_injector.K,
+    K, enc_m, m, L, scaling, use_noise, encoder_schedule = noise_injector.K,
     noise_injector.enc_m,
     noise_injector.m,
     noise_injector.L,
+    noise_injector.scaling,
     noise_injector.use_noise,
     noise_injector.encoder_schedule
+
     if use_noise
         recovered_samples = m .+ K * (samples .- enc_m)
 
-        null_samples = L * randn(size(L, 1), size(samples, 2))
+        null_samples = scaling * L * randn(size(L, 1), size(samples, 2))
         return recovered_samples + null_samples
     else
         return decode_data(encoder_schedule, samples, "in")
@@ -941,7 +955,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Lift back the encoded samples into the full space. Similar to using `decode_data`, except that this additionally injects noise from the prior when the encoding is determined to be sufficiently lossy (total lost variance < keyword `boost_for_loss`). This is done in a way that preserves any known correlations between reduced and null-space directions, which is important for posterior reconstruction.
+Lift back the encoded samples into the full space. Similar to using `decode_data`, except that this additionally injects noise from the prior when the encoding is determined to be sufficiently lossy (total lost variance < keyword `noise_injector_threshold`). This is done in a way that preserves any known correlations between reduced and null-space directions, which is important for posterior reconstruction.
 
 The quantification of correlation depends on Gaussian assumptions, and therefore is approximate. 
 """
@@ -949,9 +963,10 @@ function decode_and_add_noise(
     encoder_schedule::VV,
     samples::MM,
     prior::PD,
-    boost_for_loss::FT,
+    noise_injector_threshold::FT,
+    noise_injector_scaling::FT,
 ) where {MM <: AbstractMatrix, PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
-    noise_injector = create_noise_injector(encoder_schedule, prior, boost_for_loss)
+    noise_injector = create_noise_injector(encoder_schedule, prior, noise_injector_threshold, noise_injector_scaling)
     return decode_and_add_noise(noise_injector, samples)
 end
 

--- a/src/Utilities/elementwise_scaler.jl
+++ b/src/Utilities/elementwise_scaler.jl
@@ -122,6 +122,11 @@ returns the `struct_decoder_mat` field of the `ElementwiseScaler`.
 """
 get_struct_decoder_mat(es::ElementwiseScaler) = es.struct_decoder_mat
 
+# for now, we have these getters for consistency with other encoders
+get_encoder_mat(es::ElementwiseScaler) = es.struct_encoder_mat
+get_decoder_mat(es::ElementwiseScaler) = es.struct_decoder_mat
+
+
 function Base.show(io::IO, es::ElementwiseScaler)
     out = "ElementwiseScaler: $(get_type(es))"
     print(io, out)

--- a/src/Utilities/elementwise_scaler.jl
+++ b/src/Utilities/elementwise_scaler.jl
@@ -123,7 +123,18 @@ returns the `struct_decoder_mat` field of the `ElementwiseScaler`.
 get_struct_decoder_mat(es::ElementwiseScaler) = es.struct_decoder_mat
 
 # for now, we have these getters for consistency with other encoders
+"""
+$(TYPEDSIGNATURES)
+
+returns the `struct_encoder_mat` field of the `ElementwiseScaler`. For Consistent API with other encoders
+"""
 get_encoder_mat(es::ElementwiseScaler) = es.struct_encoder_mat
+
+"""
+$(TYPEDSIGNATURES)
+
+returns the `struct_decoder_mat` field of the `ElementwiseScaler`. For Consistent API with other encoders
+"""
 get_decoder_mat(es::ElementwiseScaler) = es.struct_decoder_mat
 
 

--- a/test/Emulator/runtests.jl
+++ b/test/Emulator/runtests.jl
@@ -115,7 +115,7 @@ end
 
     io_pairs = PairedDataContainer(x, y, data_are_columns = true)
 
-    # Test forward map wrapper with default encoding
+    # Test forward map wrapper with default encoding (remove noise injection for test)
     fmw = forward_map_wrapper(G, prior, io_pairs)
     @test get_forward_map(fmw) == G
     @test get_prior(fmw) == prior
@@ -134,19 +134,19 @@ end
     x_test = PD.sample(prior, m)
     y_test = reduce(hcat, G(transform_unconstrained_to_constrained(prior, xcol)) for xcol in eachcol(x_test))
 
-    y_pred, y_cov = EM.predict(fmw, x_test; transform_to_real = true)
+    y_pred, y_cov = EM.predict(fmw, x_test, add_obs_noise_cov = true)
     @test all(isapprox(norm(y_pred - y_test), 0; atol = sqrt(d * m) * tol))
     sample_Σ = decode_structure_matrix(fmw, I, "out")
     @test all(isapprox(norm(sample_Σ - yc), 0; atol = d * tol) for yc in y_cov)
 
-    y_pred_enc, y_cov_enc = EM.predict(fmw, x_test; transform_to_real = false)
+    y_pred_enc, y_cov_enc = EM.predict(fmw, x_test; encode = "out")
     y_test_enc = encode_data(fmw, y_test, "out")
     @test all(isapprox(norm(y_pred_enc - y_test_enc), 0; atol = sqrt(d * m) * tol))
-    @test_throws ArgumentError EM.predict(fmw, x_test'; transform_to_real = true)
+    @test_throws ArgumentError EM.predict(fmw, x_test')
 
     # with out enc.
     fmw = forward_map_wrapper(G, prior, io_pairs, encoder_kwargs = (; obs_noise_cov = Σ))
-    y_pred, y_cov = EM.predict(fmw, x_test; transform_to_real = true)
+    y_pred, y_cov = EM.predict(fmw, x_test, add_obs_noise_cov = true)
     @test all(isapprox(norm(yc - Σ), 0; atol = d * tol) for yc in y_cov)
     # try pass encoder for input
     new_schedule = (decorrelate_sample_cov(), "in") # for these i

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -206,6 +206,11 @@ using CalibrateEmulateSample.Utilities
     new_inputs[:, 3] = [π, π / 2]
     new_inputs[:, 4] = [3 * π / 2, 2 * π]
 
+    # First is just to test deprecation message!
+    _, _ = Emulators.predict(em4_noise_learnt, new_inputs; transform_to_real = true)
+    _, _ = Emulators.predict(em4_noise_learnt, new_inputs; transform_to_real = false)
+
+    # continue with example
     μ4_noise_learnt, σ4²_noise_learnt = Emulators.predict(em4_noise_learnt, new_inputs; add_obs_noise_cov = true)
     tol_mu = 0.25
 

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -206,7 +206,7 @@ using CalibrateEmulateSample.Utilities
     new_inputs[:, 3] = [π, π / 2]
     new_inputs[:, 4] = [3 * π / 2, 2 * π]
 
-    μ4_noise_learnt, σ4²_noise_learnt = Emulators.predict(em4_noise_learnt, new_inputs, transform_to_real = true)
+    μ4_noise_learnt, σ4²_noise_learnt = Emulators.predict(em4_noise_learnt, new_inputs; add_obs_noise_cov = true)
     tol_mu = 0.25
 
     @test μ4_noise_learnt[:, 1] ≈ [1.0, -1.0] atol = tol_mu
@@ -216,7 +216,7 @@ using CalibrateEmulateSample.Utilities
     @test length(σ4²_noise_learnt) == size(new_inputs, 2)
     @test size(σ4²_noise_learnt[1]) == (d, d)
 
-    μ4_noise_from_Σ, σ4²_noise_from_Σ = Emulators.predict(em4_noise_from_Σ, new_inputs, transform_to_real = true)
+    μ4_noise_from_Σ, σ4²_noise_from_Σ = Emulators.predict(em4_noise_from_Σ, new_inputs; add_obs_noise_cov = true)
 
     @test μ4_noise_from_Σ[:, 1] ≈ [1.0, -1.0] atol = tol_mu
     @test μ4_noise_from_Σ[:, 2] ≈ [0.0, 2.0] atol = tol_mu
@@ -243,7 +243,7 @@ using CalibrateEmulateSample.Utilities
 
     em_agp_from_gp4 = Emulator(agp4, iopairs2; encoder_kwargs = (; obs_noise_cov = Σ), kernel_params = kernel_params)
 
-    μ4b, σ4b² = Emulators.predict(em_agp_from_gp4, new_inputs, transform_to_real = true)
+    μ4b, σ4b² = Emulators.predict(em_agp_from_gp4, new_inputs; add_obs_noise_cov = true)
 
     # gp1 and agp_from_gp2 should give similar predictions
     tol_small = 1e-12

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -259,7 +259,10 @@ function mcmc_test_template(
 
     mcmc = MCMCWrapper(mcmc_alg, obs_sample, prior, em) # without ICs
 
-    @test all(isapprox.(getfield(get_sample_kwargs(mcmc), :initial_params), mean(prior)))
+    enc_sch = get_encoder_schedule(em)
+    mp = ndims(prior) > 1 ? mean(prior) : [mean(prior)]
+    encoded_ics = encode_data(enc_sch, reshape(mp, : ,1), "in")
+    @test all(isapprox.(getfield(get_sample_kwargs(mcmc), :initial_params), encoded_ics))
 
     mcmc = MCMCWrapper(mcmc_alg, obs_sample, prior, em; init_params = init_params)
     # First let's run a short chain to determine a good step size

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -266,10 +266,10 @@ function mcmc_test_template(
 
     mcmc = MCMCWrapper(mcmc_alg, obs_sample, prior, em; init_params = init_params)
     # First let's run a short chain to determine a good step size
-    new_step = optimize_stepsize(mcmc; init_stepsize = step, N = 5000, target_acc = target_acc)
+    new_step = optimize_stepsize(mcmc; init_stepsize = step, N = 2000, target_acc = target_acc)
 
     # Now begin the actual MCMC, sample is multiply exported so we qualify
-    chain = MCMC.sample(rng, mcmc, 50_000; stepsize = new_step, discard_initial = 10000)
+    chain = MCMC.sample(rng, mcmc, 10_000; stepsize = new_step, discard_initial = 10000)
     posterior_distribution = get_posterior(mcmc, chain)
     if TEST_PLOT_OUTPUT
         # plot:

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -261,7 +261,7 @@ function mcmc_test_template(
 
     enc_sch = get_encoder_schedule(em)
     mp = ndims(prior) > 1 ? mean(prior) : [mean(prior)]
-    encoded_ics = encode_data(enc_sch, reshape(mp, : ,1), "in")
+    encoded_ics = encode_data(enc_sch, reshape(mp, :, 1), "in")
     @test all(isapprox.(getfield(get_sample_kwargs(mcmc), :initial_params), encoded_ics))
 
     mcmc = MCMCWrapper(mcmc_alg, obs_sample, prior, em; init_params = init_params)

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -609,6 +609,20 @@ end
         # asses the covariance of the remainder
         C_rem = cov(full_samples - det_part, dims = 2)
         @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol = input_dim / sqrt(n_samples)) #  N is huge
+
+        # check noise injector components:
+        noise_injector = create_noise_injector(lossy_sch, prior_mv, 0.0)
+        @test isapprox(norm(K - noise_injector.K), 0; atol = tol * size(K, 1) * size(K, 2))
+        @test isapprox(norm(E * m - noise_injector.enc_m), 0; atol = tol * size(noise_injector.enc_m, 1))
+        @test isapprox(norm(m - noise_injector.m), 0; atol = tol * size(m, 1))
+        @test isapprox(
+            norm(cholesky(Symmetric(C_rem + 1e-12 * I)).L - noise_injector.L),
+            0;
+            atol = tol * size(noise_injector.L, 1) * size(noise_injector.L, 2) / 2,
+        )
+        @test noise_injector.use_noise
+
+
     end
 
 

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -42,7 +42,7 @@ function validate_emulator(em, data_name, prior, test_data_kwargs; exp_name = "t
     end
 
 
-    μ_valid, σ2_valid = Emulators.predict(em, get_inputs(validation_data), transform_to_real = true)
+    μ_valid, σ2_valid = Emulators.predict(em, get_inputs(validation_data); add_obs_noise_cov = true)
     rmse_valid = norm(μ_valid - get_outputs(validation_data)) ./ sqrt(size(get_outputs(validation_data), 2))
     avg_σ2_valid = mean([norm(ss) for ss in σ2_valid])
     @info "$(exp_name) \n per-point - Emulator RMSE = $rmse_valid \n Emulator STD = $(sqrt(avg_σ2_valid))\n (These numbers should be similar sized to indicate no overfitting)"

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -569,7 +569,8 @@ end
         initialize_and_encode_with_schedule!(lossless_sch, iopairs_mv; prior_cov = cov(prior_mv))
 
         enc_samples = encode_data(lossless_sch, samples, "in")
-        full_samples = decode_and_add_noise(lossless_sch, enc_samples, prior_mv, 1.0) # 1.0 = no boosting, should be like decoding
+        ni_scaling = 1.0 # don't scale the noise injected samples
+        full_samples = decode_and_add_noise(lossless_sch, enc_samples, prior_mv, 1.0, ni_scaling) # 1.0 = no boosting, should be like decoding
         tol = 1e-12
         enc_factor = size(enc_samples, 1) * size(enc_samples, 2)
         dec_factor = size(full_samples, 1) * size(full_samples, 2)
@@ -581,12 +582,12 @@ end
 
         enc_samples = encode_data(lossy_sch, samples, "in")
         # -> without noise injection
-        dec_samples = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.25) # should not boost (0.25>0.2)
+        dec_samples = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.25, ni_scaling) # should not boost (0.25>0.2)
         @test isapprox(norm(dec_samples - decode_data(lossy_sch, enc_samples, "in")), 0; atol = tol * dec_factor)
         @test isapprox(norm(encode_data(lossy_sch, dec_samples, "in") - enc_samples), 0; atol = tol * enc_factor)
 
         # -> with noise injection
-        full_samples = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.15) # should boost (0.15 < 0.2)
+        full_samples = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.15, ni_scaling) # should boost (0.15 < 0.2)
 
         # check re encoding samples gives same reduced samples (will be rough when lossy drops larger variance %)
         bigger_tol = 1e-6
@@ -611,7 +612,7 @@ end
         @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol = input_dim / sqrt(n_samples)) #  N is huge
 
         # check noise injector components:
-        noise_injector = create_noise_injector(lossy_sch, prior_mv, 0.0)
+        noise_injector = create_noise_injector(lossy_sch, prior_mv, 0.0, 0.5)
         @test isapprox(norm(K - noise_injector.K), 0; atol = tol * size(K, 1) * size(K, 2))
         @test isapprox(norm(E * m + b - noise_injector.enc_m), 0; atol = tol * size(noise_injector.enc_m, 1))
         @test isapprox(norm(m - noise_injector.m), 0; atol = tol * size(m, 1))
@@ -620,7 +621,8 @@ end
             0;
             atol = input_dim / sqrt(n_samples),
         )
-        @test noise_injector.use_noise
+        @test noise_injector.use_noise # check for noise_injector_threshold
+        @test noise_injector.scaling == 0.5
 
 
     end

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -608,7 +608,7 @@ end
 
         # asses the covariance of the remainder
         C_rem = cov(full_samples - det_part, dims = 2)
-        @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol = 0.1 * input_dim / sqrt(n_samples)) #  N is huge
+        @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol = input_dim / sqrt(n_samples)) #  N is huge
     end
 
 

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -560,55 +560,59 @@ end
         prior_mv = test_prior_mv(input_dim)
         test_data_mv_kwargs = (; input_dim = input_dim)
         y_mv, σ2_y_mv, iopairs_mv, rng_mv = test_data_mv(prior_mv; test_data_mv_kwargs...) # iopairs unconstrained inputs
-        
+
         # new data
-        samples = 0.1*collect(1:input_dim).*randn(input_dim, n_samples)
+        samples = 0.1 * collect(1:input_dim) .* randn(input_dim, n_samples)
 
         # lossless encoding
-        lossless_sch = create_encoder_schedule((minmax_scale(), "in"))        
-        initialize_and_encode_with_schedule!(lossless_sch, iopairs_mv; prior_cov=cov(prior_mv))
+        lossless_sch = create_encoder_schedule((minmax_scale(), "in"))
+        initialize_and_encode_with_schedule!(lossless_sch, iopairs_mv; prior_cov = cov(prior_mv))
 
         enc_samples = encode_data(lossless_sch, samples, "in")
         full_samples = decode_and_add_noise(lossless_sch, enc_samples, prior_mv, 1.0) # 1.0 = no boosting, should be like decoding
         tol = 1e-12
-        enc_factor = size(enc_samples,1) * size(enc_samples,2)
-        dec_factor = size(full_samples,1) * size(full_samples,2)
-        @test isapprox(norm(full_samples - decode_data(lossless_sch, enc_samples, "in")), 0 ; atol=tol*dec_factor)
+        enc_factor = size(enc_samples, 1) * size(enc_samples, 2)
+        dec_factor = size(full_samples, 1) * size(full_samples, 2)
+        @test isapprox(norm(full_samples - decode_data(lossless_sch, enc_samples, "in")), 0; atol = tol * dec_factor)
 
         # lossy encoding
-        lossy_sch = create_encoder_schedule((decorrelate_sample_cov(retain_var=0.8), "in")) # lossy drops ~ 0.2 variance       
-        initialize_and_encode_with_schedule!(lossy_sch, iopairs_mv; prior_cov=cov(prior_mv))
-        
+        lossy_sch = create_encoder_schedule((decorrelate_sample_cov(retain_var = 0.8), "in")) # lossy drops ~ 0.2 variance       
+        initialize_and_encode_with_schedule!(lossy_sch, iopairs_mv; prior_cov = cov(prior_mv))
+
         enc_samples = encode_data(lossy_sch, samples, "in")
         # -> without noise injection
         dec_samples = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.25) # should not boost (0.25>0.2)
-        @test isapprox(norm(dec_samples - decode_data(lossy_sch, enc_samples, "in")), 0 ; atol=tol*dec_factor)
-        @test isapprox(norm(encode_data(lossy_sch, dec_samples, "in") - enc_samples), 0; atol=tol*enc_factor)
-        
+        @test isapprox(norm(dec_samples - decode_data(lossy_sch, enc_samples, "in")), 0; atol = tol * dec_factor)
+        @test isapprox(norm(encode_data(lossy_sch, dec_samples, "in") - enc_samples), 0; atol = tol * enc_factor)
+
         # -> with noise injection
         full_samples = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.15) # should boost (0.15 < 0.2)
 
         # check re encoding samples gives same reduced samples (will be rough when lossy drops larger variance %)
         bigger_tol = 1e-6
-        @test isapprox(norm(encode_data(lossy_sch, full_samples, "in") - enc_samples), 0; atol=bigger_tol*enc_factor)
+        @test isapprox(
+            norm(encode_data(lossy_sch, full_samples, "in") - enc_samples),
+            0;
+            atol = bigger_tol * enc_factor,
+        )
 
         # check that the fill-in has distribution that matches C - KEC
         # compute deterinistic part
         E, b = get_encoder_from_schedule(lossy_sch, "in")
         E = Matrix(E)
         C = cov(prior_mv)
-        m = reshape(mean(prior_mv), :, 1)       
+        m = reshape(mean(prior_mv), :, 1)
         ECEt = cholesky(Symmetric(E * C * E' + 1e-12I))
         K = C * E' * (ECEt \ I)
-        det_part = m .+ K * (enc_samples .- (E*m .+ b))
+        det_part = m .+ K * (enc_samples .- (E * m .+ b))
 
         # asses the covariance of the remainder
-        C_rem = cov(full_samples - det_part,dims=2)          
-        @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol=0.1*input_dim/sqrt(n_samples)) #  N is huge
+        C_rem = cov(full_samples - det_part, dims = 2)
+        @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol = 0.1 * input_dim / sqrt(n_samples)) #  N is huge
     end
 
 
-     @testset "Autodiff MCMC variants" begin
+    @testset "Autodiff MCMC variants" begin
         mcmc_algs = [
             RWMHSampling(), # sanity-check
             BarkerSampling(), # ForwardDiffProtocol by default

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -238,7 +238,6 @@ function test_vrfi(y, σ2_y, iopairs::PairedDataContainer)
     return em
 end
 
-
 function mcmc_test_template(
     prior::ParameterDistribution,
     σ2_y,
@@ -331,7 +330,7 @@ end
     validate_emulator(em_1b, "test_data", prior, test_data_kwargs, exp_name = "agpjl_1d")
     validate_emulator(em_2, "test_data", prior, test_data_kwargs, exp_name = "gpjl-svd_1d")
 
-    # [2.] 10D -> 1D
+    # [2.] 5D -> 1D
     # setup
     obs_sample_mv = [5.0]
     input_dim = 5
@@ -552,7 +551,64 @@ end
         end
     end
 
-    @testset "Autodiff MCMC variants" begin
+
+    @testset "Test the encode-decode for posterior samples" begin
+
+        # build a mv problem in input space
+        input_dim = 10
+        n_samples = 5000
+        prior_mv = test_prior_mv(input_dim)
+        test_data_mv_kwargs = (; input_dim = input_dim)
+        y_mv, σ2_y_mv, iopairs_mv, rng_mv = test_data_mv(prior_mv; test_data_mv_kwargs...) # iopairs unconstrained inputs
+        
+        # new data
+        samples = 0.1*collect(1:input_dim).*randn(input_dim, n_samples)
+
+        # lossless encoding
+        lossless_sch = create_encoder_schedule((minmax_scale(), "in"))        
+        initialize_and_encode_with_schedule!(lossless_sch, iopairs_mv; prior_cov=cov(prior_mv))
+
+        enc_samples = encode_data(lossless_sch, samples, "in")
+        full_samples = decode_and_add_noise(lossless_sch, enc_samples, prior_mv, 1.0) # 1.0 = no boosting, should be like decoding
+        tol = 1e-12
+        enc_factor = size(enc_samples,1) * size(enc_samples,2)
+        dec_factor = size(full_samples,1) * size(full_samples,2)
+        @test isapprox(norm(full_samples - decode_data(lossless_sch, enc_samples, "in")), 0 ; atol=tol*dec_factor)
+
+        # lossy encoding
+        lossy_sch = create_encoder_schedule((decorrelate_sample_cov(retain_var=0.8), "in")) # lossy drops ~ 0.2 variance       
+        initialize_and_encode_with_schedule!(lossy_sch, iopairs_mv; prior_cov=cov(prior_mv))
+        
+        enc_samples = encode_data(lossy_sch, samples, "in")
+        # -> without noise injection
+        dec_samples = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.25) # should not boost (0.25>0.2)
+        @test isapprox(norm(dec_samples - decode_data(lossy_sch, enc_samples, "in")), 0 ; atol=tol*dec_factor)
+        @test isapprox(norm(encode_data(lossy_sch, dec_samples, "in") - enc_samples), 0; atol=tol*enc_factor)
+        
+        # -> with noise injection
+        full_samples = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.15) # should boost (0.15 < 0.2)
+
+        # check re encoding samples gives same reduced samples (will be rough when lossy drops larger variance %)
+        bigger_tol = 1e-6
+        @test isapprox(norm(encode_data(lossy_sch, full_samples, "in") - enc_samples), 0; atol=bigger_tol*enc_factor)
+
+        # check that the fill-in has distribution that matches C - KEC
+        # compute deterinistic part
+        E, b = get_encoder_from_schedule(lossy_sch, "in")
+        E = Matrix(E)
+        C = cov(prior_mv)
+        m = reshape(mean(prior_mv), :, 1)       
+        ECEt = cholesky(Symmetric(E * C * E' + 1e-12I))
+        K = C * E' * (ECEt \ I)
+        det_part = m .+ K * (enc_samples .- (E*m .+ b))
+
+        # asses the covariance of the remainder
+        C_rem = cov(full_samples - det_part,dims=2)          
+        @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol=0.1*input_dim/sqrt(N)) #  N is huge
+    end
+
+
+     @testset "Autodiff MCMC variants" begin
         mcmc_algs = [
             RWMHSampling(), # sanity-check
             BarkerSampling(), # ForwardDiffProtocol by default
@@ -585,5 +641,4 @@ end
             end
         end
     end
-
 end

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -604,7 +604,7 @@ end
 
         # asses the covariance of the remainder
         C_rem = cov(full_samples - det_part,dims=2)          
-        @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol=0.1*input_dim/sqrt(N)) #  N is huge
+        @test isapprox(norm(C_rem - (C - K * E * C)), 0; atol=0.1*input_dim/sqrt(n_samples)) #  N is huge
     end
 
 

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -269,7 +269,7 @@ function mcmc_test_template(
     new_step = optimize_stepsize(mcmc; init_stepsize = step, N = 2000, target_acc = target_acc)
 
     # Now begin the actual MCMC, sample is multiply exported so we qualify
-    chain = MCMC.sample(rng, mcmc, 10_000; stepsize = new_step, discard_initial = 10000)
+    chain = MCMC.sample(rng, mcmc, 20_000; stepsize = new_step, discard_initial = 2_000)
     posterior_distribution = get_posterior(mcmc, chain)
     if TEST_PLOT_OUTPUT
         # plot:

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -613,12 +613,12 @@ end
         # check noise injector components:
         noise_injector = create_noise_injector(lossy_sch, prior_mv, 0.0)
         @test isapprox(norm(K - noise_injector.K), 0; atol = tol * size(K, 1) * size(K, 2))
-        @test isapprox(norm(E * m - noise_injector.enc_m), 0; atol = tol * size(noise_injector.enc_m, 1))
+        @test isapprox(norm(E * m + b - noise_injector.enc_m), 0; atol = tol * size(noise_injector.enc_m, 1))
         @test isapprox(norm(m - noise_injector.m), 0; atol = tol * size(m, 1))
         @test isapprox(
             norm(cholesky(Symmetric(C_rem + 1e-12 * I)).L - noise_injector.L),
             0;
-            atol = tol * size(noise_injector.L, 1) * size(noise_injector.L, 2) / 2,
+            atol = input_dim / sqrt(n_samples),
         )
         @test noise_injector.use_noise
 

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -362,13 +362,13 @@ rng = Random.MersenneTwister(seed)
 
         # predict and test at the new inputs
         tol_μ = 0.1 * ntest
-        μs, σs² = Emulators.predict(em_srfi, new_inputs, transform_to_real = true)
+        μs, σs² = Emulators.predict(em_srfi, new_inputs; add_obs_noise_cov = true)
         @test size(μs) == (1, ntest)
         @test size(σs²) == (1, ntest)
         @test isapprox.(norm(μs - new_outputs), 0, atol = tol_μ)
         @test all(isapprox.(vec(σs²), 0.05^2 * ones(ntest), atol = 1e-2))
 
-        μv, σv² = Emulators.predict(em_vrfi, new_inputs, transform_to_real = true)
+        μv, σv² = Emulators.predict(em_vrfi, new_inputs; add_obs_noise_cov = true)
         @test size(μv) == (1, ntest)
         @test size(σv²) == (1, ntest)
         @test isapprox.(norm(μv - new_outputs), 0, atol = tol_μ)
@@ -480,12 +480,12 @@ rng = Random.MersenneTwister(seed)
         outx[1, :] = sin.(new_inputs[1, :]) .+ cos.(new_inputs[2, :])
         outx[2, :] = sin.(new_inputs[1, :]) .- cos.(new_inputs[2, :])
 
-        μ_ssd, σ²_ssd = Emulators.predict(em_srfi_svd_diagin, new_inputs, transform_to_real = true)
-        μ_ss, σ²_ss = Emulators.predict(em_srfi_svd, new_inputs, transform_to_real = true)
-        μ_vsd, σ²_vsd = Emulators.predict(em_vrfi_svd_diagout, new_inputs, transform_to_real = true)
-        μ_vs, σ²_vs = Emulators.predict(em_vrfi_svd, new_inputs, transform_to_real = true)
-        μ_v, σ²_v = Emulators.predict(em_vrfi, new_inputs)
-        μ_vns, σ²_vns = Emulators.predict(em_vrfi_nonsep, new_inputs)
+        μ_ssd, σ2_ssd = Emulators.predict(em_srfi_svd_diagin, new_inputs)
+        μ_ss, σ2_ss = Emulators.predict(em_srfi_svd, new_inputs)
+        μ_vsd, σ2_vsd = Emulators.predict(em_vrfi_svd_diagout, new_inputs)
+        μ_vs, σ2_vs = Emulators.predict(em_vrfi_svd, new_inputs)
+        μ_v, σ2_v = Emulators.predict(em_vrfi, new_inputs)
+        μ_vns, σ2_vns = Emulators.predict(em_vrfi_nonsep, new_inputs)
 
         tol_μ = 0.1 * ntest * output_dim
         @test isapprox.(norm(μ_ssd - outx), 0, atol = tol_μ)
@@ -494,6 +494,10 @@ rng = Random.MersenneTwister(seed)
         @test isapprox.(norm(μ_vs - outx), 0, atol = tol_μ)
         @test isapprox.(norm(μ_v - outx), 0, atol = 2 * tol_μ) # approximate option so likely less good approx
         @test isapprox.(norm(μ_vns - outx), 0, atol = 2 * tol_μ) # approximate option so likely less good approx
+        @info norm.([σ2_ssd, σ2_ss, σ2_vsd, σ2_vs, σ2_v, σ2_vns])
+        @test all(isapprox.(norm.([σ2_ssd, σ2_ss, σ2_vsd, σ2_vs]), 0; atol = tol_μ)) # the emulator uncert. of the mean
+        @test all(isapprox.(norm.([σ2_v, σ2_vns]), 0; atol = 2 * tol_μ))
+
         # An example with the other threading option
         vrfi_tul = VectorRandomFeatureInterface(
             n_features,
@@ -504,8 +508,9 @@ rng = Random.MersenneTwister(seed)
             rng = rng,
         )
         em_vrfi_svd_tul = Emulator(vrfi_tul, iopairs; encoder_kwargs = (; obs_noise_cov = Σ))
-        μ_vs_tul, σ²_vs_tul = Emulators.predict(em_vrfi_svd_tul, new_inputs, transform_to_real = true)
+        μ_vs_tul, σ2_vs_tul = Emulators.predict(em_vrfi_svd_tul, new_inputs)
         @test isapprox.(norm(μ_vs_tul - outx), 0, atol = tol_μ)
+        @test all(isapprox.(norm.(σ2_vs_tul), 0; atol = tol_μ))
 
     end
 

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -409,9 +409,12 @@ end
     tol = 1e-12
     schedules = [
         (zscore_scale(), "in_and_out"),
-        (decorrelate_sample_cov(), "in_and_out"),
-        (canonical_correlation(), "in_and_out"),
         (decorrelate_structure_mat(retain_var = 0.95), "in_and_out"),
+        [(canonical_correlation(), "in_and_out"), (zscore_scale(), "in_and_out")],
+        [
+            (decorrelate_sample_cov(retain_var = 0.99), "in_and_out"),
+            (decorrelate_sample_cov(retain_var = 0.99), "in_and_out"), # reduce dim twice
+        ],
     ]
 
     for sch in schedules

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -395,41 +395,50 @@ end
     enc1= get_encoder_from_schedule([]) 
     Ein,ain = enc1["in"]
     Eout,aout = enc1["out"]
-    @test all(isnothing.(Ein,ain,Eout,aout))
+    @test all(isnothing.([Ein,ain,Eout,aout]))
 
     dec1= get_decoder_from_schedule([]) 
     Din,bin = dec1["in"]
     Dout,bout = dec1["out"]
-    @test all(isnothing.(Din,bin,Dout,bout))
+    @test all(isnothing.([Din,bin,Dout,bout]))
 
-    @test_throws get_encoder_from_schedule(schedules[1],"not_in_or_out")
-    @test_throws get_decoder_from_schedule(schedules[1],"not_in_or_out")
+    @test_throws ArgumentError get_encoder_from_schedule([schedules[1]],"not_in_or_out")
+    @test_throws ArgumentError get_decoder_from_schedule([schedules[1]],"not_in_or_out")
 
     # test for some schedules
     tol = 1e-12
-    for schedule in schedules[1,4,7]
-        enc2 = get_encoder_from_schedule(schedule)
-        dec2 = get_decoder_from_schedule(schedule)
-
-        in_dat = get_inputs(io_pairs)[:,1]
-        out_dat = get_outputs(io_pairs)[:,1]
+    schedules = [
+        (zscore_scale(), "in_and_out"),
+        (decorrelate_sample_cov(), "in_and_out"),
+        (canonical_correlation(), "in_and_out"),
+        (decorrelate_structure_mat(retain_var = 0.95), "in_and_out"),
+    ]
+    
+    for sch in schedules
+        encoder_schedule = create_encoder_schedule(sch)
+        (encoded_io_pairs, encoded_input_structure_mats, encoded_output_structure_mats, _, _) =
+            initialize_and_encode_with_schedule!(encoder_schedule, io_pairs; prior_cov, obs_noise_cov)
+        enc2 = get_encoder_from_schedule(encoder_schedule)
+        dec2 = get_decoder_from_schedule(encoder_schedule)
+        in_dat = reshape(get_inputs(io_pairs)[:,1], :, 1)
+        out_dat = reshape(get_outputs(io_pairs)[:,1], :, 1)
         in_mat = in_dat*in_dat'
         out_mat = out_dat*out_dat'
-        for (i_o, dat, mat) in (("in" in_dat, in_mat), ("out", out_dat, out_mat))
-            enc_dat = encode_data(schedule, dat, i_o)
-            dec_dat = decode_data(schedule, enc_dat, i_o)
-            enc_mat = encode_structure_matrix(schedule, mat, i_o)
-            dec_mat = decode_structure_matrix(schedule, enc_mat, i_o)
-            
+        for (i_o, dat, mat) in (("in", in_dat, in_mat), ("out", out_dat, out_mat))            
+            enc_dat = encode_data(encoder_schedule, dat, i_o)
+            dec_dat = decode_data(encoder_schedule, enc_dat, i_o)
+            enc_mat = Matrix(encode_structure_matrix(encoder_schedule, mat, i_o))
+            dec_mat = Matrix(decode_structure_matrix(encoder_schedule, enc_mat, i_o))
             # retrieve 
             E,a = enc2[i_o]
             D,b = dec2[i_o]
-
+            E = Matrix(E)
+            D = Matrix(D)
+           
             @test isapprox(norm((E*dat+a) - enc_dat), 0; atol = tol * size(E,1))
             @test isapprox(norm((D*enc_dat+b) - dec_dat), 0; atol = tol * size(D,1))            
-            @test isapprox(norm(Matrix(E*dat*E') - Matrix(enc_mat)), 0; atol= tol*size(E,1)^2)
-            @test isapprox(norm(Matrix(D*enc_mat*D') - Matrix(dec_mat)), 0; atol= tol*size(D,1)^2)
-            
+            @test isapprox(norm(E*mat*E' - enc_mat), 0; atol= tol*size(E,1)^2)
+            @test isapprox(norm(D*enc_mat*D' - dec_mat), 0; atol= tol*size(D,1)^2)            
         end
     end
     

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -390,6 +390,49 @@ end
 
     end
 
+    # test retrieval of the affine components from the schedule
+    # nothing option
+    enc1= get_encoder_from_schedule([]) 
+    Ein,ain = enc1["in"]
+    Eout,aout = enc1["out"]
+    @test all(isnothing.(Ein,ain,Eout,aout))
+
+    dec1= get_decoder_from_schedule([]) 
+    Din,bin = dec1["in"]
+    Dout,bout = dec1["out"]
+    @test all(isnothing.(Din,bin,Dout,bout))
+
+    @test_throws get_encoder_from_schedule(schedules[1],"not_in_or_out")
+    @test_throws get_decoder_from_schedule(schedules[1],"not_in_or_out")
+
+    # test for some schedules
+    tol = 1e-12
+    for schedule in schedules[1,4,7]
+        enc2 = get_encoder_from_schedule(schedule)
+        dec2 = get_decoder_from_schedule(schedule)
+
+        in_dat = get_inputs(io_pairs)[:,1]
+        out_dat = get_outputs(io_pairs)[:,1]
+        in_mat = in_dat*in_dat'
+        out_mat = out_dat*out_dat'
+        for (i_o, dat, mat) in (("in" in_dat, in_mat), ("out", out_dat, out_mat))
+            enc_dat = encode_data(schedule, dat, i_o)
+            dec_dat = decode_data(schedule, enc_dat, i_o)
+            enc_mat = encode_structure_matrix(schedule, mat, i_o)
+            dec_mat = decode_structure_matrix(schedule, enc_mat, i_o)
+            
+            # retrieve 
+            E,a = enc2[i_o]
+            D,b = dec2[i_o]
+
+            @test isapprox(norm((E*dat+a) - enc_dat), 0; atol = tol * size(E,1))
+            @test isapprox(norm((D*enc_dat+b) - dec_dat), 0; atol = tol * size(D,1))            
+            @test isapprox(norm(Matrix(E*dat*E') - Matrix(enc_mat)), 0; atol= tol*size(E,1)^2)
+            @test isapprox(norm(Matrix(D*enc_mat*D') - Matrix(dec_mat)), 0; atol= tol*size(D,1)^2)
+            
+        end
+    end
+    
     # test throws on lack of sample_mat
     sch2a = (decorrelate_structure_mat(), "in")
     schedule2a = create_encoder_schedule(sch2a)
@@ -427,8 +470,7 @@ end
         obs_noise_cov,
     )
     @test_throws ArgumentError decode_with_schedule(bad_encoder_schedule, io_pairs, prior_cov, obs_noise_cov)
-
-
+    
     encoder_schedule = create_encoder_schedule(schedule_builder)
 
     # encode the data using the schedule

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -392,18 +392,18 @@ end
 
     # test retrieval of the affine components from the schedule
     # nothing option
-    enc1= get_encoder_from_schedule([]) 
-    Ein,ain = enc1["in"]
-    Eout,aout = enc1["out"]
-    @test all(isnothing.([Ein,ain,Eout,aout]))
+    enc1 = get_encoder_from_schedule([])
+    Ein, ain = enc1["in"]
+    Eout, aout = enc1["out"]
+    @test all(isnothing.([Ein, ain, Eout, aout]))
 
-    dec1= get_decoder_from_schedule([]) 
-    Din,bin = dec1["in"]
-    Dout,bout = dec1["out"]
-    @test all(isnothing.([Din,bin,Dout,bout]))
+    dec1 = get_decoder_from_schedule([])
+    Din, bin = dec1["in"]
+    Dout, bout = dec1["out"]
+    @test all(isnothing.([Din, bin, Dout, bout]))
 
-    @test_throws ArgumentError get_encoder_from_schedule([schedules[1]],"not_in_or_out")
-    @test_throws ArgumentError get_decoder_from_schedule([schedules[1]],"not_in_or_out")
+    @test_throws ArgumentError get_encoder_from_schedule([schedules[1]], "not_in_or_out")
+    @test_throws ArgumentError get_decoder_from_schedule([schedules[1]], "not_in_or_out")
 
     # test for some schedules
     tol = 1e-12
@@ -413,35 +413,35 @@ end
         (canonical_correlation(), "in_and_out"),
         (decorrelate_structure_mat(retain_var = 0.95), "in_and_out"),
     ]
-    
+
     for sch in schedules
         encoder_schedule = create_encoder_schedule(sch)
         (encoded_io_pairs, encoded_input_structure_mats, encoded_output_structure_mats, _, _) =
             initialize_and_encode_with_schedule!(encoder_schedule, io_pairs; prior_cov, obs_noise_cov)
         enc2 = get_encoder_from_schedule(encoder_schedule)
         dec2 = get_decoder_from_schedule(encoder_schedule)
-        in_dat = reshape(get_inputs(io_pairs)[:,1], :, 1)
-        out_dat = reshape(get_outputs(io_pairs)[:,1], :, 1)
-        in_mat = in_dat*in_dat'
-        out_mat = out_dat*out_dat'
-        for (i_o, dat, mat) in (("in", in_dat, in_mat), ("out", out_dat, out_mat))            
+        in_dat = reshape(get_inputs(io_pairs)[:, 1], :, 1)
+        out_dat = reshape(get_outputs(io_pairs)[:, 1], :, 1)
+        in_mat = in_dat * in_dat'
+        out_mat = out_dat * out_dat'
+        for (i_o, dat, mat) in (("in", in_dat, in_mat), ("out", out_dat, out_mat))
             enc_dat = encode_data(encoder_schedule, dat, i_o)
             dec_dat = decode_data(encoder_schedule, enc_dat, i_o)
             enc_mat = Matrix(encode_structure_matrix(encoder_schedule, mat, i_o))
             dec_mat = Matrix(decode_structure_matrix(encoder_schedule, enc_mat, i_o))
             # retrieve 
-            E,a = enc2[i_o]
-            D,b = dec2[i_o]
+            E, a = enc2[i_o]
+            D, b = dec2[i_o]
             E = Matrix(E)
             D = Matrix(D)
-           
-            @test isapprox(norm((E*dat+a) - enc_dat), 0; atol = tol * size(E,1))
-            @test isapprox(norm((D*enc_dat+b) - dec_dat), 0; atol = tol * size(D,1))            
-            @test isapprox(norm(E*mat*E' - enc_mat), 0; atol= tol*size(E,1)^2)
-            @test isapprox(norm(D*enc_mat*D' - dec_mat), 0; atol= tol*size(D,1)^2)            
+
+            @test isapprox(norm((E * dat + a) - enc_dat), 0; atol = tol * size(E, 1))
+            @test isapprox(norm((D * enc_dat + b) - dec_dat), 0; atol = tol * size(D, 1))
+            @test isapprox(norm(E * mat * E' - enc_mat), 0; atol = tol * size(E, 1)^2)
+            @test isapprox(norm(D * enc_mat * D' - dec_mat), 0; atol = tol * size(D, 1)^2)
         end
     end
-    
+
     # test throws on lack of sample_mat
     sch2a = (decorrelate_structure_mat(), "in")
     schedule2a = create_encoder_schedule(sch2a)
@@ -479,7 +479,7 @@ end
         obs_noise_cov,
     )
     @test_throws ArgumentError decode_with_schedule(bad_encoder_schedule, io_pairs, prior_cov, obs_noise_cov)
-    
+
     encoder_schedule = create_encoder_schedule(schedule_builder)
 
     # encode the data using the schedule


### PR DESCRIPTION
Co-authored by @ArneBouillon 

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #400 
- Closes #380
- Closes #372
## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- For the `predict()` for both `Emulator` and `ForwardMapWrapper`
  - Added deprecation notice to `transform_to_real=false` kwarg. Removed this from all tests (except to test the deprecation message)
  - Added `add_obs_noise_cov=false` kwarg to predict. when set true, this adds the regularization to the machine learning tool
  - Added `encode=nothing` to the predict method, when set to `"in", "out", "in_and_out"` it will take in / push out encoded/decoded outputs.
  - When encoding inputs, with `ForwardMapWrapper`, samples are decoded into the output space before application
  
API is now improved for user experience
```julia
# (User) typical to predict at new points:
y_pred, y_pred_cov = predict(em_or_fmw, new_inputs) 

# (Internal) call within encoded MCMC, with full uncertainty
g_pred, g_pred_cov = predict(em_or_fmw, new_inputs, encode="in_and_out", add_obs_noise_cov=true) 
```
  

- When retrieving MCMC posterior, if a sufficiently lossy encoder is used noise is injected into the null space from the prior (and correlation-aware). This is separated so one can precompute quantities, stored in `NoiseInjector` and then use `decode_and_add_noise(noise_injector, samples)` to apply the decoding. Users can also set
  - `noise_injector_threshold` (to determine how lossy before injection)
  - `noise_injector_scaling` (in case the injection results in instability due to Gaussian assumptions)
- Added utility `get_encoder_from_schedule` to return `E,b` from an `encoder_schedule` defining an affine encoding `Ex + b`
- Added new docstrings and improved existing docstrings
- Full unit testing. 
 

## Misc
- example testing. Works on `Sinusoid` example, [now testing on Darcy...]
- Bugfix for arguments of `_predict` , `,` -> `;`
- Create issue for removing transform_to_real from docs/examples #411

## Detail on current encoding setup
Current settings: full (F) vs reduced (R) space
- Emulator space (R)
- MCMC: initial conditions (R)
- MCMC: computing likelihood (R)
- MCMC: stored encoded prior distribution (R)
- MCMC: computing logpdf(encoded_prior,x) (R)  
- MCMC: output posterior samples (F) (decoding each posterior sample + add correlated noise in null space from the prior)
- ForwardMapWrapper: predict, (F)  (decoding each posterior sample + add correlated noise in null space from the prior)
## Darcy example - [updated since review]
We compare, lossless encoding. Lossy encoding  without inflation, Lossy encoding (retain 99.5%var) with inflation, and the truth. We look for the lossy encoding to by increased by using the prior variance. The D utility indicates the amount of contraction from prior to posterior (by comparison of determinants)

`Lossless` - (20D->50D), D utility O(10^11)
<img width="1500" height="400" alt="GP_posterior_pointwise_uq_noloss" src="https://github.com/user-attachments/assets/e7166e05-3f92-4019-a0c5-1d0ba7418897" />
`Lossy - inflate` - (19D->15D), D utility O(10^11)
<img width="1500" height="400" alt="GP_posterior_pointwise_uq_inflated" src="https://github.com/user-attachments/assets/81c5c498-d62e-455a-9046-39ab0b86025d" />
`Lossy - no inflate` - (19D->15D), D utility O(10^29)
<img width="1500" height="400" alt="GP_posterior_pointwise_uq_non_inflate" src="https://github.com/user-attachments/assets/1881a0c0-c7b8-420a-b02f-6bd79b57dd59" />
`true`
<img width="1000" height="400" alt="output_true" src="https://github.com/user-attachments/assets/6c901a40-733b-4426-885e-b716174601d7" />

## Sinusoid example
Encoding truncates to ignore one of the (independent) parameters. So null space of the encoder means one samples the prior. Here we compare inflation with scaling 1, 0.2, and no inflation.
`With inflation (GP, RF, ForwardMap)`
<img width="200" alt="sinusoid_MCMC_hist_GP_inflate" src="https://github.com/user-attachments/assets/417b7d4b-3b8f-4a53-94e4-f158be968af3" /> <img width="200" alt="sinusoid_MCMC_hist_RF_inflate" src="https://github.com/user-attachments/assets/cfc421dd-3bc9-4b26-82d0-e8c01a440936" /> <img width="200" alt="sinusoid_MCMC_hist_FM_inflate" src="https://github.com/user-attachments/assets/2c3b16ac-7cce-4744-95e2-320df619f019" />
`With inflation scaled by 0.2 (GP, RF, ForwardMap)`

<img width="200" alt="sinusoid_MCMC_hist_GP" src="https://github.com/user-attachments/assets/07028b41-7892-4063-a173-8ae5a06fa62d" /> <img width="200" alt="sinusoid_MCMC_hist_RF" src="https://github.com/user-attachments/assets/260fb603-7c1f-4c0d-b40e-367cc2edf069" /> <img width="200" alt="sinusoid_MCMC_hist_FM" src="https://github.com/user-attachments/assets/871ebc27-ca27-4799-8d07-9936084f616b" />
`Without inflation (GP, RF, ForwardMap)`
<img width="200" alt="sinusoid_MCMC_hist_GP" src="https://github.com/user-attachments/assets/412eef98-aaec-43f4-a6f7-a4a9a38ce38a" /> <img width="200" alt="sinusoid_MCMC_hist_RF" src="https://github.com/user-attachments/assets/8163347f-d844-4aa3-a02d-bdc1391cea02" /> <img width="200" alt="sinusoid_MCMC_hist_FM" src="https://github.com/user-attachments/assets/a2f706a9-6870-4d2a-8039-6c2a6c9206f2" />







<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
