### PR TITLE
Downgrade python in unit tests to 3.11 to stop random failures

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -35,9 +35,9 @@ jobs:
       env:
         PYTHON: ""
       run: |
-        julia --project -e 'using Conda; Conda.add("python=3.13")' 
-        julia --project -e 'using Conda; Conda.add("scipy=1.17.1")'
-        julia --project -e 'using Conda; Conda.add("scikit-learn=1.8.0")'
+        julia --project -e 'using Conda; Conda.add("python=3.11")' 
+        julia --project -e 'using Conda; Conda.add("scipy=1.14.1")'
+        julia --project -e 'using Conda; Conda.add("scikit-learn=1.5.1")'
         julia --project -e 'using Pkg; Pkg.add("PyCall"); Pkg.build("PyCall")'     
 
     - name: Run Unit Tests
@@ -91,9 +91,9 @@ jobs:
       env:
         PYTHON: ""
       run: |
-        julia --project -e 'using Conda; Conda.add("python=3.13")'
-        julia --project -e 'using Conda; Conda.add("scipy=1.17.1")'
-        julia --project -e 'using Conda; Conda.add("scikit-learn=1.8.0")'
+        julia --project -e 'using Conda; Conda.add("python=3.11")'
+        julia --project -e 'using Conda; Conda.add("scipy=1.14.1")'
+        julia --project -e 'using Conda; Conda.add("scikit-learn=1.5.1")'
         julia --project -e 'using Pkg; Pkg.add("PyCall"); Pkg.build("PyCall")'
         
     - name: Run Unit Tests
@@ -134,9 +134,9 @@ jobs:
       env:
         PYTHON: ""
       run: |
-        julia --project -e 'using Conda; Conda.add("python=3.13")'
-        julia --project -e 'using Conda; Conda.add("scipy=1.17.0")'
-        julia --project -e 'using Conda; Conda.add("scikit-learn=1.8.0")'
+        julia --project -e 'using Conda; Conda.add("python=3.11")'
+        julia --project -e 'using Conda; Conda.add("scipy=1.14.1")'
+        julia --project -e 'using Conda; Conda.add("scikit-learn=1.5.1")'
         julia --project -e 'using Pkg; Pkg.add("PyCall"); Pkg.build("PyCall")'     
     - name: Run Unit Tests
       env:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,15 @@
 using Test
 
-TEST_PLOT_OUTPUT = !isempty(get(ENV, "CES_TEST_PLOT_OUTPUT", ""))
+TEST_PLOT_OUTPUT = get(ENV, "CES_TEST_PLOT_OUTPUT", false)
+@info "[in test/runtest.jl], create plots? CES_TEST_PLOT_OUTPUT: $(TEST_PLOT_OUTPUT)"
 
 if TEST_PLOT_OUTPUT
     using Plots
 end
 
+ENV["SKLEARN_JL_VERSION"] = "1.5.1"
+sklearn_jl_version = get(ENV, "SKLEARN_JL_VERSION", "1.8.0")
+@info "[in test/runtest.jl], (if running Github actions) this variable must match the scikit learn version in .github/workflows/tests.yml. SKLEARN_JL_VERSION: $(sklearn_jl_version)"
 
 function include_test(_module)
     println("Starting tests for $_module")


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #415


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- downgrade tests to 3.11
- add info statement to help keep consistency in testing

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
