### PR TITLE
fixed bug with 1d

### DIFF
--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -1163,7 +1163,7 @@ function create_noise_injector(
     end
 
     C = cov(prior)
-    m = reshape(mean(prior), :, 1)
+    m = (ndims(prior) > 1) ? reshape(mean(prior), :, 1) : [mean(prior)]
     E = Matrix(E)
 
     enc_m = E * m + b

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -1163,7 +1163,7 @@ function create_noise_injector(
     end
 
     C = cov(prior)
-    m = (ndims(prior) > 1) ? reshape(mean(prior), :, 1) : fill(mean(prior),1,1)
+    m = (ndims(prior) > 1) ? reshape(mean(prior), :, 1) : fill(mean(prior), 1, 1)
     E = Matrix(E)
 
     enc_m = E * m + b

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -1163,7 +1163,7 @@ function create_noise_injector(
     end
 
     C = cov(prior)
-    m = (ndims(prior) > 1) ? reshape(mean(prior), :, 1) : [mean(prior)]
+    m = (ndims(prior) > 1) ? reshape(mean(prior), :, 1) : fill(mean(prior),1,1)
     E = Matrix(E)
 
     enc_m = E * m + b

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -8,6 +8,7 @@ using CalibrateEmulateSample.EnsembleKalmanProcesses
 using CalibrateEmulateSample.MarkovChainMonteCarlo
 const MCMC = MarkovChainMonteCarlo
 using CalibrateEmulateSample.ParameterDistributions
+const PD = CalibrateEmulateSample.ParameterDistributions
 using CalibrateEmulateSample.Emulators
 using CalibrateEmulateSample.DataContainers
 using CalibrateEmulateSample.Utilities
@@ -628,8 +629,8 @@ end
         input_dim = 1
         n_samples = 10
         prior_1d = constrained_gaussian("1d-check", 0, 1, -Inf, 5)
-        in_data = sample(prior_1d, n_samples)
-        out_data = sample(prior_1d, n_samples)
+        in_data = PD.sample(prior_1d, n_samples)
+        out_data = PD.sample(prior_1d, n_samples)
         io_pairs_1d = PairedDataContainer(in_data, out_data, data_are_columns = true)
 
         # lossless encoding

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -8,7 +8,7 @@ using CalibrateEmulateSample.EnsembleKalmanProcesses
 using CalibrateEmulateSample.MarkovChainMonteCarlo
 const MCMC = MarkovChainMonteCarlo
 using CalibrateEmulateSample.ParameterDistributions
-const PD = CalibrateEmulateSample.ParameterDistributions
+const PD = ParameterDistributions
 using CalibrateEmulateSample.Emulators
 using CalibrateEmulateSample.DataContainers
 using CalibrateEmulateSample.Utilities

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -624,6 +624,20 @@ end
         @test noise_injector.use_noise # check for noise_injector_threshold
         @test noise_injector.scaling == 0.5
 
+        # check 1D
+        input_dim = 1
+        n_samples = 10
+        prior_1d = constrained_gaussian("1d-check", 0, 1, -Inf, 5)
+        in_data = sample(prior_1d, n_samples)
+        out_data = sample(prior_1d, n_samples)
+        io_pairs_1d = PairedDataContainer(in_data, out_data, data_are_columns = true)
+
+        # lossless encoding
+        lossless_sch = create_encoder_schedule((minmax_scale(), "in"))
+        initialize_and_encode_with_schedule!(lossless_sch, io_pairs_1d; prior_cov = cov(prior_1d))
+
+        noise_injector = create_noise_injector(lossless_sch, prior_1d, 0.0, 0.5)
+
 
     end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #420

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- make mean(prior) a 1x1 matrix from a Float

## Misc
- I noticed during fixing of this bug, that `.dev/climaformat.jl` converted [x;;] into [x]. I've created #422



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
