### PR TITLE
Prevent dependabot from pushing doc previews

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -66,7 +66,10 @@ if !isempty(get(ENV, "CI", ""))
     deploydocs(
         repo = "github.com/CliMA/CalibrateEmulateSample.jl.git",
         versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
-        push_preview = true,
+        push_preview = all(
+            !isempty,
+            (get(ENV, "GITHUB_TOKEN", ""), get(ENV, "DOCUMENTER_KEY", "")),
+        ),
         devbranch = "main",
     )
 end


### PR DESCRIPTION
See [issue](https://github.com/JuliaDocs/Documenter.jl/issues/2048) in Documenter.jl. This is the solution suggested there.

Dependabot PRs run without access to repository secrets, so `GITHUB_TOKEN`/`DOCUMENTER_KEY` are unavailable and `push_preview = true` causes doc preview pushes to fail. This only enables `push_preview` when both env vars are present.