### PR TITLE
Fixing encoder-decoder bugs in [audit 2026-07-09], Add `fix-prompt-applier` skill

### DIFF
--- a/.claude/skills/fix-prompt-applier/SKILL.md
+++ b/.claude/skills/fix-prompt-applier/SKILL.md
@@ -108,15 +108,53 @@ written for) re-discovers a "bug" that's already closed.
   all of their rows and sections together so the document reflects the whole
   batch consistently, not a half-updated intermediate state.
 
-### 5. Report back
+### 5. Check whether other open prompts just went stale
+
+A fix can change shared code — a struct's fields, a function's signature, a
+calling convention — that some *other*, still-open fix-prompt in the same
+directory also quotes. If so, that prompt's line numbers and snippets are now
+misleading in exactly the way step 2 already tells you to watch out for in
+the prompt you're actively applying — except the next person to pick up that
+other prompt won't have this session's context to notice it. A fix-prompt
+only saves time if it's trustworthy; a stale one costs the next session (or
+model) the same rediscovery work you just did.
+
+Resist the urge to fully rewrite that other prompt, though, even if you can
+see exactly what changed. Re-deriving whether its claimed bug is still real
+against the new code is an audit judgment call — the same adversarial
+re-derivation math-auditor does, not a byproduct of applying an unrelated
+fix — and overwriting its Problem/Required-change text would destroy the
+historical record of what the bug looked like at audit time, for the same
+reason step 4 appends review.md status rather than rewriting a finding.
+
+So, cheaply:
+- Grep the fix-prompts directory for other prompts whose `File`/`Where`
+  section names a file you just edited.
+- Skip any already marked fixed (check `review.md` or the prompt itself).
+- Of the rest, check whether the specific function, struct, or snippet *that
+  prompt quotes* was actually touched by your edit — not just "same file".
+  Most fixes are narrow and won't overlap with what another prompt cares
+  about; this should usually turn up nothing, and that's fine.
+- Where there's real overlap, append (don't rewrite) a short note to that
+  prompt:
+  ```
+  **Note (updated <date>)**: the code this prompt describes may have moved —
+  <what changed, e.g. "the sampler struct fields this prompt references were
+  renamed in the <ID> fix on <date>">. Re-verify the current source before
+  trusting this prompt's line numbers/snippets; do not assume they still match.
+  ```
+
+### 6. Report back
 
 For each fix ID applied, state: what changed and where (`file:line`), which
 test/invariant now pins it, whether any existing test's expected value needed
-updating (and why, citing the README/prompt note that justified it), and
-whether `review.md` was updated (or why it was skipped). Keep this compact —
-one or two lines per ID — the point is a scannable record of what's fixed and
-what now guards it, not a re-explanation of the math (that's already in the
-review and the prompt).
+updating (and why, citing the README/prompt note that justified it), whether
+`review.md` was updated (or why it was skipped), and whether any other
+fix-prompts were flagged as stale (name them, or say none needed it — don't
+pad this line when step 5 found nothing). Keep this compact — one or two
+lines per ID — the point is a scannable record of what's fixed and what now
+guards it, not a re-explanation of the math (that's already in the review and
+the prompt).
 
 ## Improving this skill
 

--- a/.claude/skills/fix-prompt-applier/SKILL.md
+++ b/.claude/skills/fix-prompt-applier/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: fix-prompt-applier
+description: >
+  Apply fixes described in full-code-review/<date>/fix-prompts/<ID>-<slug>.md
+  files — the self-contained fix prompts produced by the math-auditor skill
+  after an adversarial mathematical review — and, once a fix is verified, mark
+  the finding as resolved in the parent review.md so the review stays a living
+  record of what's fixed vs. still open. Use this skill whenever the user asks
+  to fix, implement, or apply a finding by its ID (e.g. "fix C1", "apply the
+  M7 fix", "implement the fix-prompts for the likelihood-informed processor"),
+  asks to work through a review's fix-prompts/README.md in order, or
+  references a full-code-review directory at all. Trigger even if the user
+  doesn't say "fix-prompt" explicitly — any request to act on findings from an
+  existing math/code review report qualifies.
+---
+
+# Fix-Prompt Applier
+
+Counterpart to **math-auditor**: math-auditor produces a review plus a
+directory of self-contained fix prompts; this skill consumes them, usually in
+a later session (or a smaller model) with none of the audit's context. Every
+fix prompt was written assuming exactly that — treat each one as the full
+brief, not a pointer into a conversation you don't have.
+
+## Workflow
+
+### 1. Locate and read before touching any code
+
+- Find the fix-prompt file(s) for the requested ID(s) under
+  `full-code-review/**/fix-prompts/`. IDs are stable (`C1…` critical, `M1…`
+  major, `m1…` minor, `h1…` hygiene, `G1…` grouped-minor).
+- If `fix-prompts/README.md` exists, read it first: it gives the recommended
+  application order, flags same-file prompts that must be sequenced together,
+  and — importantly — names which fixes **intentionally change numerical
+  results**. That last part matters at verification time: a regression test
+  that starts failing after such a fix isn't a new bug, it was pinned to the
+  old, wrong behavior.
+- Read each fix-prompt file **in full**. They follow a fixed shape (File /
+  Problem / Required change / Do not / Verify) precisely so nothing besides
+  the prompt itself is needed — don't skim just the required-change line and
+  move on.
+
+### 2. Apply
+
+- Find the offending code by the function name and snippet quoted in the
+  prompt. Line numbers drift between the audit and the fix session — treat
+  them as hints, not anchors; the quoted snippet is what actually locates it.
+- Make exactly the described change. Read the "Do not" guardrails literally —
+  they exist because the prompt's author already considered the tempting
+  adjacent change (a broader refactor, an API change, "fixing" a neighboring
+  function too) and rejected it. A fix prompt is deliberately narrow, usually
+  one finding in ~40 lines; don't expand scope while you're in there.
+- When several fix prompts touch the same file (e.g. two findings in the same
+  function, or in the same processor), read all of them before editing any of
+  them, and land the edits together so the file is mathematically consistent
+  at every intermediate step — don't let one fix's change invalidate another
+  prompt's line references or assumptions about the surrounding code.
+- If a prompt's description seems ambiguous, or seems to contradict what the
+  current code actually does (code drifts between the audit and the fix
+  session too), re-read the source and re-derive the math yourself rather than
+  guessing. The prompt is the best available hint; the source is ground truth.
+
+### 3. Verify
+
+- Run, or add, exactly the test or invariant the prompt's "Verify" section
+  names — this is the thing that pins the fix and stops the bug from silently
+  coming back.
+- If a pre-existing test fails after the change, check the README (or the
+  prompt itself) for a note that this fix intentionally changes numerical
+  results before treating the failure as a regression. If it's flagged, update
+  the test's expected/reference value to the correct analytic or numerical
+  value the prompt derives — don't revert the fix to make the old value pass
+  again.
+- Beyond the named test, run the package's broader relevant test suite (the
+  module's test file at minimum) to catch collateral breakage the narrow
+  Verify step wouldn't show.
+
+### 4. Update `review.md` so it stays a living record
+
+A fix-prompt is a snapshot of a bug at audit time. Once it's fixed and
+verified, the parent review should say so — otherwise the next reader
+(including a future instance of you, or the smaller model this skill was
+written for) re-discovers a "bug" that's already closed.
+
+- Find `review.md` next to the fix-prompts directory (`../review.md` relative
+  to `fix-prompts/`, i.e. `full-code-review/<date>/review.md`). If it doesn't
+  exist — e.g. someone handed you a fix-prompt file on its own — skip this
+  step rather than erroring; there's nothing to update.
+- Get today's date from the shell (`date +%F`), the same way math-auditor
+  dates its report directories. Don't recall or guess a date from memory —
+  it's cheap to get exactly right and confusing to get wrong.
+- In the **summary table**, mark the fixed finding's row, e.g. append
+  `— FIXED (<date>)` to its Verdict cell. Reuse the Verdict column rather than
+  inventing a new one, unless the table already has a Status column or the
+  Verdict cell would get unreadably cluttered.
+- In the finding's own detailed section (under Critical/Major/Minor/Hygiene
+  findings), append — don't rewrite — a short status note directly below the
+  existing text:
+  ```
+  **Status**: Fixed <date> — <1-3 sentences: what changed, `file:line`, which
+  test/invariant now pins it>. Applied via the fix-prompt-applier skill.
+  ```
+  Leave the original finding text (evidence, math, failure scenario) exactly
+  as it is — that's the historical record of what was wrong and how it was
+  found. review.md is meant to double as an audit trail: a reader should see
+  both what the bug was and that it's now closed, without losing either.
+- If a single pass fixed several findings (e.g. two in the same file), update
+  all of their rows and sections together so the document reflects the whole
+  batch consistently, not a half-updated intermediate state.
+
+### 5. Report back
+
+For each fix ID applied, state: what changed and where (`file:line`), which
+test/invariant now pins it, whether any existing test's expected value needed
+updating (and why, citing the README/prompt note that justified it), and
+whether `review.md` was updated (or why it was skipped). Keep this compact —
+one or two lines per ID — the point is a scannable record of what's fixed and
+what now guards it, not a re-explanation of the math (that's already in the
+review and the prompt).
+
+## Improving this skill
+
+After applying fixes, offer: "Would you like to improve the
+**fix-prompt-applier** skill itself using skill-creator? You can share
+suggestions, or I can analyze this session — where a prompt was ambiguous,
+where scope crept, whether verification actually caught anything — to refine
+the skill for next time."

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -334,7 +334,11 @@ function predict(
     encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
 
     if !(isnothing(encode) || encode ∈ ("in", "out", "in_and_out"))
-        throw(ArgumentError("keyword `encode` must be nothing, \"in\", \"out\", or \"in_and_out\"; received $(repr(encode))"))
+        throw(
+            ArgumentError(
+                "keyword `encode` must be nothing, \"in\", \"out\", or \"in_and_out\"; received $(repr(encode))",
+            ),
+        )
     end
 
     # For the logic below
@@ -512,7 +516,11 @@ function predict(
     encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
 
     if !(isnothing(encode) || encode ∈ ("in", "out", "in_and_out"))
-        throw(ArgumentError("keyword `encode` must be nothing, \"in\", \"out\", or \"in_and_out\"; received $(repr(encode))"))
+        throw(
+            ArgumentError(
+                "keyword `encode` must be nothing, \"in\", \"out\", or \"in_and_out\"; received $(repr(encode))",
+            ),
+        )
     end
 
     # For the logic below

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -333,6 +333,10 @@ function predict(
 
     encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
 
+    if !(isnothing(encode) || encode ∈ ("in", "out", "in_and_out"))
+        throw(ArgumentError("keyword `encode` must be nothing, \"in\", \"out\", or \"in_and_out\"; received $(repr(encode))"))
+    end
+
     # For the logic below
     in_already_encoded = encode ∈ ["in", "in_and_out"]
     out_to_be_decoded = encode ∉ ["out", "in_and_out"]
@@ -506,6 +510,10 @@ function predict(
 ) where {FMW <: ForwardMapWrapper, AM <: AbstractMatrix}
 
     encode, add_obs_noise_cov = deprecate_transform_to_real(encode, add_obs_noise_cov, transform_to_real)
+
+    if !(isnothing(encode) || encode ∈ ("in", "out", "in_and_out"))
+        throw(ArgumentError("keyword `encode` must be nothing, \"in\", \"out\", or \"in_and_out\"; received $(repr(encode))"))
+    end
 
     # For the logic below
     in_already_encoded = encode ∈ ["in", "in_and_out"]

--- a/src/MachineLearningTools/ScalarRandomFeature.jl
+++ b/src/MachineLearningTools/ScalarRandomFeature.jl
@@ -422,8 +422,19 @@ function build_models!(
             _throw_unknown_multithread(multithread)
         end
         # scale up the prior so that default priors are always "reasonable"
-        prior_in_scale = 1.0 ./ std(input_values, dims = 2)
+        in_std = std(input_values, dims = 2)
+        if any(iszero, in_std)
+            const_in_dims = findall(iszero, vec(in_std))
+            @warn "ScalarRandomFeature: constant input dimension(s) $(const_in_dims) detected; using scale = 1 for those dimensions."
+            in_std = map(s -> iszero(s) ? one(s) : s, in_std)
+        end
+        prior_in_scale = 1.0 ./ in_std
+
         prior_out_scale = std(output_values[i, :])
+        if iszero(prior_out_scale)
+            @warn "ScalarRandomFeature: constant output detected for model $i; using scale = 1."
+            prior_out_scale = one(prior_out_scale)
+        end
 
         prior = build_default_prior(input_dim, kernel_structure)
 

--- a/src/MachineLearningTools/VectorRandomFeature.jl
+++ b/src/MachineLearningTools/VectorRandomFeature.jl
@@ -412,8 +412,20 @@ function build_models!(
     end
 
     # scale up the prior so that default priors are always "reasonable"
-    prior_in_scale = 1.0 ./ std(input_values, dims = 2)
+    in_std = std(input_values, dims = 2)
+    if any(iszero, in_std)
+        const_in_dims = findall(iszero, vec(in_std))
+        @warn "VectorRandomFeature: constant input dimension(s) $(const_in_dims) detected; using scale = 1 for those dimensions."
+        in_std = map(s -> iszero(s) ? one(s) : s, in_std)
+    end
+    prior_in_scale = 1.0 ./ in_std
+
     prior_out_scale = std(output_values, dims = 2)
+    if any(iszero, prior_out_scale)
+        const_out_dims = findall(iszero, vec(prior_out_scale))
+        @warn "VectorRandomFeature: constant output dimension(s) $(const_out_dims) detected; using scale = 1 for those dimensions."
+        prior_out_scale = map(s -> iszero(s) ? one(s) : s, prior_out_scale)
+    end
 
     # Optimize feature cholesky factors with EKP
     # [1.] Split data into test/train (e.g. 80/20)

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -1055,6 +1055,7 @@ samples in `chain`.
 # Arguments
 - `noise_injector_threshold` (`=0.001`): If the encoded space is lossy, and the lost variability due to encoding exceeds this threshold, then in place of decoding posterior samples, additional noise consistent with the prior is injected into the null space of the encoder. See `decode_and_add_noise()` for more detail.
 - `noise_injector_scaling` (`=1.0`): Scales the injected noise; though 1.0 is the only "consistent" value, reduction may be necessary if noise injection causes posterior samples to be unstable in simulations.
+- `rng` (`=Random.GLOBAL_RNG`): random number generator used to draw the injected null-space noise, when applicable.
 
 !!! note
     This method does not currently support combining samples from multiple `Chains`.
@@ -1064,6 +1065,7 @@ function get_posterior(
     chain::MCMCChains.Chains;
     noise_injector_threshold::FT = 0.001,
     noise_injector_scaling::FT = 1.0,
+    rng::Random.AbstractRNG = Random.GLOBAL_RNG,
 ) where {FT <: Real}
     p_names = get_name(mcmc.prior)
     p_slices = batch(mcmc.prior)
@@ -1083,7 +1085,8 @@ function get_posterior(
         red_samples,
         mcmc.prior,
         noise_injector_threshold,
-        noise_injector_scaling,
+        noise_injector_scaling;
+        rng = rng,
     )
 
     p_samples = [Samples(full_samples[slice, :], params_are_columns = true) for slice in p_slices]

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -184,7 +184,10 @@ via [`MetropolisHastingsSampler`](@ref) applied to a [`pCNMHSampling`](@ref) pro
 
 $(TYPEDFIELDS)
 """
-struct pCNMetropolisHastings{LT, T <: AutodiffProtocol} <: AdvancedMH.MHSampler
+struct pCNMetropolisHastings{VT, LT, T <: AutodiffProtocol} <: AdvancedMH.MHSampler
+    "Mean `m` of the (encoded) prior. pCN's proposal contracts toward this point (not toward 0,
+    which is only correct when the encoded prior happens to be zero-mean)."
+    prior_mean::VT
     "Lower Cholesky factor `L` of the (encoded) prior covariance `C = LL'`, shaping the proposal noise."
     cholesky_L::LT
 end
@@ -193,8 +196,9 @@ function MetropolisHastingsSampler(
     encoded_prior::ParameterDistribution,
     encoder_schedule::VV,
 ) where {T <: AutodiffProtocol, VV <: AbstractVector}
+    m = mean(encoded_prior)
     L = _get_cholesky_factor(encoded_prior, encoder_schedule)
-    return pCNMetropolisHastings{typeof(L), T}(L)
+    return pCNMetropolisHastings{typeof(m), typeof(L), T}(m, L)
 end
 
 #------ The following are gradient-based samplers
@@ -456,11 +460,14 @@ function transition_kernel(
     return MvNormal(θ_from, Symmetric((stepsize^2) .* (L * L')))
 end
 
-# θ_to | θ_from ~ N(ρθ_from, (1-ρ²)C) — the asymmetric pCN kernel (Beskos et al. 2017 for the
-# ρ-vs-Euler-stepsize relation). Evaluating this honestly in both directions (via the generic
-# logratio_proposal_density) is what recovers the pCN cancellation log q(θ_from|θ_to) -
-# log q(θ_to|θ_from) = logprior(θ_from) - logprior(θ_to), instead of the silently-symmetric 0
-# the previous implementation returned.
+# θ_to | θ_from ~ N(m + ρ(θ_from - m), (1-ρ²)C) — the asymmetric pCN kernel (Beskos et al. 2017
+# for the ρ-vs-Euler-stepsize relation), contracting toward the encoded prior mean `m` rather
+# than toward 0 (correct in general; 0 is only the special case m=0). Evaluating this honestly
+# in both directions (via the generic logratio_proposal_density) is what recovers the pCN
+# cancellation log q(θ_from|θ_to) - log q(θ_to|θ_from) = logprior(θ_from) - logprior(θ_to): the
+# shift v = θ - m turns this kernel into the m=0 case in v-coordinates, where that cancellation
+# is the standard pCN identity, and N(m,C) in θ-coordinates is exactly N(0,C) in v-coordinates,
+# so the identity carries over unchanged.
 function transition_kernel(
     sampler::pCNMetropolisHastings,
     model::AdvancedMH.DensityModel,
@@ -468,8 +475,9 @@ function transition_kernel(
     stepsize::FT = 1.0,
 ) where {FT <: AbstractFloat}
     ρ = (1 - stepsize / 4) / (1 + stepsize / 4)
+    m = sampler.prior_mean
     L = sampler.cholesky_L
-    return MvNormal(ρ .* θ_from, Symmetric((1 - ρ^2) .* (L * L')))
+    return MvNormal(m .+ ρ .* (θ_from .- m), Symmetric((1 - ρ^2) .* (L * L')))
 end
 
 """

--- a/src/MarkovChainMonteCarlo.jl
+++ b/src/MarkovChainMonteCarlo.jl
@@ -460,14 +460,8 @@ function transition_kernel(
     return MvNormal(θ_from, Symmetric((stepsize^2) .* (L * L')))
 end
 
-# θ_to | θ_from ~ N(m + ρ(θ_from - m), (1-ρ²)C) — the asymmetric pCN kernel (Beskos et al. 2017
-# for the ρ-vs-Euler-stepsize relation), contracting toward the encoded prior mean `m` rather
-# than toward 0 (correct in general; 0 is only the special case m=0). Evaluating this honestly
-# in both directions (via the generic logratio_proposal_density) is what recovers the pCN
-# cancellation log q(θ_from|θ_to) - log q(θ_to|θ_from) = logprior(θ_from) - logprior(θ_to): the
-# shift v = θ - m turns this kernel into the m=0 case in v-coordinates, where that cancellation
-# is the standard pCN identity, and N(m,C) in θ-coordinates is exactly N(0,C) in v-coordinates,
-# so the identity carries over unchanged.
+# θ_to | θ_from ~ N(m + ρ(θ_from - m), (1-ρ²)C) — the asymmetric pCN kernel (Beskos et al. 2017),
+# contracting toward the encoded prior mean `m` rather than toward 0.
 function transition_kernel(
     sampler::pCNMetropolisHastings,
     model::AdvancedMH.DensityModel,

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -1410,9 +1410,11 @@ Suggestion:
 end
 
 @noinline function _throw_unsupported_block_type(a, i::Int, total::Int)
-    throw(ArgumentError(
-        "create_compact_linear_map: block $i (of $total) has unsupported type $(typeof(a)); expected AbstractMatrix, SVD, or SVDplusD.",
-    ))
+    throw(
+        ArgumentError(
+            "create_compact_linear_map: block $i (of $total) has unsupported type $(typeof(a)); expected AbstractMatrix, SVD, or SVDplusD.",
+        ),
+    )
 end
 
 # Processors

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -37,7 +37,8 @@ export create_encoder_schedule,
     NoiseInjector,
     decode_and_add_noise,
     create_noise_injector,
-    get_encoded_dim
+    get_encoded_dim,
+    is_initialized
 
 
 const StructureMatrix = Union{UniformScaling, AbstractMatrix, AbstractVector, LinearMap} # The vector appears due to possible block-structured matrices (build=false)
@@ -767,9 +768,9 @@ function create_encoder_schedule(schedule_in::VV) where {VV <: AbstractVector}
     for (processor, apply_to) in schedule_in
         # converts the string into the extraction of data
         if apply_to ∈ ["in", "out"]
-            push!(encoder_schedule, (processor, apply_to))
+            push!(encoder_schedule, (deepcopy(processor), apply_to))
         elseif apply_to == "in_and_out"
-            push!(encoder_schedule, (processor, "in"))
+            push!(encoder_schedule, (deepcopy(processor), "in"))
             push!(encoder_schedule, (deepcopy(processor), "out"))
         else
             @warn(
@@ -845,6 +846,10 @@ function initialize_and_encode_with_schedule!(
     end
     if !isnothing(samples_out)
         (output_structure_vecs[:samples_out] = samples_out)
+    end
+
+    if any(is_initialized(processor) for (processor, apply_to) in encoder_schedule)
+        @warn "Encoder schedule contains already-initialized processors; they will NOT be refitted to the new data. Create a fresh schedule with create_encoder_schedule to refit."
     end
 
     # apply_to is the string "in", "out" etc.

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -485,15 +485,17 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Approximate the `p`-norm of a `LinearMap` `A` using random matrix–vector products,
-satisfying `norm_linear_map(A, p) ≈ norm(Matrix(A), p)`. Can be called via `norm(A, p)`.
+Randomized estimate of the Frobenius norm of a `LinearMap` `A` (`p = 2`); values for
+`p ≠ 2` are heuristic and can be badly wrong for structured operators. Can be called via
+`norm(A, p)`.
 
 # Arguments
 
 - `A`: the `LinearMap` to evaluate.
 - `p` (default `2`): norm order.
 - `n_eval` (keyword, default `nothing`): number of matrix–vector products; defaults to
-  `size(A, 2)` (exact for `p=2`, approximate otherwise).
+  `size(A, 2)`. Even at this default the estimate is randomized (unbiased in squared
+  Frobenius norm, several-percent error in practice), not exact.
 - `rng` (keyword, default `Random.default_rng()`): random number generator.
 """
 function norm_linear_map(A::LM, p::Real = 2; n_eval = nothing, rng = Random.default_rng()) where {LM <: LinearMap}
@@ -501,7 +503,7 @@ function norm_linear_map(A::LM, p::Real = 2; n_eval = nothing, rng = Random.defa
 
     # use unit-normalized gaussian vectors
     n_basis = isa(n_eval, Nothing) ? n : n_eval
-    samples = randn(n, n_basis)
+    samples = randn(rng, n, n_basis)
     for i in 1:size(samples, 2)
         samples[:, i] /= norm(samples[:, i])
     end

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -456,6 +456,8 @@ function create_compact_linear_map(
             push!(VTs, svda.Vt)
             push!(ds, diaga)
             bsize = length(diaga)
+        else
+            _throw_unsupported_block_type(a, i, length(Avec))
         end
 
         batch = (shift + 1):(shift + bsize)
@@ -599,10 +601,10 @@ function Base.:(==)(a::LM1, b::LM2) where {LM1 <: LinearMap, LM2 <: LinearMap}
 end
 
 Base.:(==)(a::DCP1, b::DCP2) where {DCP1 <: DataContainerProcessor, DCP2 <: DataContainerProcessor} =
-    all(getfield(a, f) == getfield(b, f) for f in fieldnames(DCP1))
+    DCP1 === DCP2 && all(getfield(a, f) == getfield(b, f) for f in fieldnames(DCP1))
 
 Base.:(==)(a::PDCP1, b::PDCP2) where {PDCP1 <: PairedDataContainerProcessor, PDCP2 <: PairedDataContainerProcessor} =
-    all(getfield(a, f) == getfield(b, f) for f in fieldnames(PDCP1))
+    PDCP1 === PDCP2 && all(getfield(a, f) == getfield(b, f) for f in fieldnames(PDCP1))
 ####
 
 function get_structure_vec(structure_vecs, name = nothing)
@@ -651,7 +653,6 @@ end
 
 # just for reshaping into matrix
 function _encode_data(proc::P, data::VV) where {P <: DataProcessor, VV <: AbstractVector}
-    data_vec = isa(data, DataContainer) ? get_data(data) : data
     if eltype(data) <: Real # one vec
         return _encode_data(proc, reshape(data, :, 1)) # reshape to column
     else # vec of vec
@@ -1351,7 +1352,8 @@ end
 
 function decode_and_add_noise(
     noise_injector::NorNI,
-    samples::MM,
+    samples::MM;
+    rng::Random.AbstractRNG = Random.GLOBAL_RNG,
 ) where {NorNI <: Union{Nothing, NoiseInjector}, MM <: AbstractMatrix}
     if isnothing(noise_injector)
         return samples
@@ -1370,7 +1372,7 @@ function decode_and_add_noise(
     if use_noise
         recovered_samples = m .+ K * (samples .- enc_m)
 
-        null_samples = scaling * L * randn(size(L, 1), size(samples, 2))
+        null_samples = scaling * L * randn(rng, size(L, 1), size(samples, 2))
         return recovered_samples + null_samples
     else
         return decode_data(encoder_schedule, samples, "in")
@@ -1389,10 +1391,11 @@ function decode_and_add_noise(
     samples::MM,
     prior::PD,
     noise_injector_threshold::FT,
-    noise_injector_scaling::FT,
+    noise_injector_scaling::FT;
+    rng::Random.AbstractRNG = Random.GLOBAL_RNG,
 ) where {MM <: AbstractMatrix, PD <: ParameterDistribution, VV <: AbstractVector, FT <: Real}
     noise_injector = create_noise_injector(encoder_schedule, prior, noise_injector_threshold, noise_injector_scaling)
-    return decode_and_add_noise(noise_injector, samples)
+    return decode_and_add_noise(noise_injector, samples; rng = rng)
 end
 
 ## Error helpers
@@ -1404,6 +1407,12 @@ Structure matrix $i (of $total) is a `UniformScaling` ("λI"), whose dimension c
 Suggestion:
     Replace `λ * I` with `Diagonal(fill(λ, d))` where `d` is the required matrix dimension.
 """))
+end
+
+@noinline function _throw_unsupported_block_type(a, i::Int, total::Int)
+    throw(ArgumentError(
+        "create_compact_linear_map: block $i (of $total) has unsupported type $(typeof(a)); expected AbstractMatrix, SVD, or SVDplusD.",
+    ))
 end
 
 # Processors

--- a/src/Utilities/canonical_correlation.jl
+++ b/src/Utilities/canonical_correlation.jl
@@ -53,6 +53,14 @@ get_encoder_mat(cc::CanonicalCorrelation) = cc.encoder_mat
 """
 $(TYPEDSIGNATURES)
 
+Returns `true` if `cc` has already been fit to data (and so `initialize_processor!` on it
+is a no-op).
+"""
+is_initialized(cc::CanonicalCorrelation) = !isempty(get_encoder_mat(cc))
+
+"""
+$(TYPEDSIGNATURES)
+
 returns the `decoder_mat` field of the `CanonicalCorrelation`.
 """
 get_decoder_mat(cc::CanonicalCorrelation) = cc.decoder_mat

--- a/src/Utilities/canonical_correlation.jl
+++ b/src/Utilities/canonical_correlation.jl
@@ -113,15 +113,7 @@ function initialize_processor!(
         svdi = svd(in_data .- mean(in_data, dims = 2))
         svdo = svd(out_data .- mean(out_data, dims = 2))
 
-        # Truncate to numerical rank so `1 ./ S` below never divides by a (near-)zero singular
-        # value, and so rank-deficient (e.g. collinear-ensemble) data doesn't inflate a
-        # near-null direction. `Ui`/`Vti` (and `Uo`/`Vto`) are then unambiguous by construction
-        # of `svd` on a (dim x n_samples) matrix with n_samples ≥ dim (guaranteed by the
-        # sample-count check above): `Ui` is the data-space factor (in_dim x r_in, orthonormal
-        # columns), `Vti` the sample-space factor (r_in x n_samples, orthonormal rows) - no
-        # size-equality role-guessing needed (that guess breaks once ranks differ under
-        # truncation, which is what made the pre-fix in/out role selection pick the wrong branch
-        # for rank-deficient data).
+        # Truncate to numerical rank so `1 ./ S` below never divides by a (near-)zero singular value.
         rank_rtol = 1e-12
         r_in = count(>(rank_rtol * svdi.S[1]), svdi.S)
         r_out = count(>(rank_rtol * svdo.S[1]), svdo.S)
@@ -139,13 +131,8 @@ function initialize_processor!(
         else
             trunc_val = min(length(svdio.S), rank(in_data), rank(out_data))
         end
-        # svdio.U spans the row-space of `Vti * Vto'` (the "in" role), svdio.V the column-space
-        # (the "out" role) - deterministic from the multiplication order above, not a
-        # size-equality guess.
-        # rescale so encoded variates have sample covariance ≈ I (matching every sibling
-        # processor: Decorrelator, ZScore, ...) instead of the CCA-standard ‖u‖² = 1 energy
-        # normalization, which left CCA-encoded data O(1/√(n_samples-1)) smaller in scale than
-        # everything else in the pipeline.
+        # svdio.U spans the row-space of `Vti * Vto'` (the "in" role), svdio.V the column-space (the "out" role).
+        # rescale so encoded variates have sample covariance ≈ I, matching every sibling processor.
         rescale = sqrt(n_samples - 1)
         if apply_to == "in"
             # mat' * Sx⁻¹ * Uxt

--- a/src/Utilities/canonical_correlation.jl
+++ b/src/Utilities/canonical_correlation.jl
@@ -99,16 +99,28 @@ function initialize_processor!(
         if size(in_data, 2) < size(in_data, 1) || size(out_data, 2) < size(out_data, 1)
             _throw_insufficient_cca_samples(in_data, out_data)
         end
+        n_samples = size(in_data, 2)
 
         # Individually decompose in and out
         svdi = svd(in_data .- mean(in_data, dims = 2))
         svdo = svd(out_data .- mean(out_data, dims = 2))
 
-        # ensure correct shaping (in_mat = (in_dim x n_samples), out_mat = (out_dim x n_samples))
-        in_mat_sq, in_mat_nonsq = (size(svdi.U, 1) == size(svdi.U, 2)) ? (svdi.U, svdi.Vt) : (svdi.Vt, svdi.U)
-        out_mat_sq, out_mat_nonsq = (size(svdo.U, 1) == size(svdo.U, 2)) ? (svdo.U, svdo.Vt) : (svdo.Vt, svdo.U)
+        # Truncate to numerical rank so `1 ./ S` below never divides by a (near-)zero singular
+        # value, and so rank-deficient (e.g. collinear-ensemble) data doesn't inflate a
+        # near-null direction. `Ui`/`Vti` (and `Uo`/`Vto`) are then unambiguous by construction
+        # of `svd` on a (dim x n_samples) matrix with n_samples ≥ dim (guaranteed by the
+        # sample-count check above): `Ui` is the data-space factor (in_dim x r_in, orthonormal
+        # columns), `Vti` the sample-space factor (r_in x n_samples, orthonormal rows) - no
+        # size-equality role-guessing needed (that guess breaks once ranks differ under
+        # truncation, which is what made the pre-fix in/out role selection pick the wrong branch
+        # for rank-deficient data).
+        rank_rtol = 1e-12
+        r_in = count(>(rank_rtol * svdi.S[1]), svdi.S)
+        r_out = count(>(rank_rtol * svdo.S[1]), svdo.S)
+        Ui, Si, Vti = svdi.U[:, 1:r_in], svdi.S[1:r_in], svdi.Vt[1:r_in, :]
+        Uo, So, Vto = svdo.U[:, 1:r_out], svdo.S[1:r_out], svdo.Vt[1:r_out, :]
 
-        svdio = svd(in_mat_nonsq * out_mat_nonsq')
+        svdio = svd(Vti * Vto')
 
         # retain variance
         ret_var = get_retain_var(cc)
@@ -117,30 +129,36 @@ function initialize_processor!(
             trunc_val = minimum(findall(x -> (x > ret_var), sv_cumsum))
             @info "    truncating at $(trunc_val)/$(length(sv_cumsum)) retaining $(100.0*sv_cumsum[trunc_val])% of the variance in the joint space"
         else
-            trunc_val = min(rank(in_data), rank(out_data))
+            trunc_val = min(length(svdio.S), rank(in_data), rank(out_data))
         end
-        in_dim = size(in_data, 1)
-        in_svdio_mat, out_svdio_mat = (size(svdio.U, 1) == in_dim) ? (svdio.U, svdio.V) : (svdio.V, svdio.U')
+        # svdio.U spans the row-space of `Vti * Vto'` (the "in" role), svdio.V the column-space
+        # (the "out" role) - deterministic from the multiplication order above, not a
+        # size-equality guess.
+        # rescale so encoded variates have sample covariance ≈ I (matching every sibling
+        # processor: Decorrelator, ZScore, ...) instead of the CCA-standard ‖u‖² = 1 energy
+        # normalization, which left CCA-encoded data O(1/√(n_samples-1)) smaller in scale than
+        # everything else in the pipeline.
+        rescale = sqrt(n_samples - 1)
         if apply_to == "in"
             # mat' * Sx⁻¹ * Uxt
-            encoder_mat = in_svdio_mat[:, 1:trunc_val]' * Diagonal(1 ./ svdi.S) * in_mat_sq'
-            decoder_mat = in_mat_sq * Diagonal(svdi.S) * in_svdio_mat[:, 1:trunc_val]
+            encoder_mat = rescale * svdio.U[:, 1:trunc_val]' * Diagonal(1 ./ Si) * Ui'
+            decoder_mat = (1 / rescale) * Ui * Diagonal(Si) * svdio.U[:, 1:trunc_val]
 
         elseif apply_to == "out"
-            out_dim = size(out_data, 1)
             # Vt * Sy⁻¹ * Uyt
-            encoder_mat = out_svdio_mat[:, 1:trunc_val]' * Diagonal(1 ./ svdo.S) * out_mat_sq'
-            decoder_mat = out_mat_sq * Diagonal(svdo.S) * out_svdio_mat[:, 1:trunc_val]
+            encoder_mat = rescale * svdio.V[:, 1:trunc_val]' * Diagonal(1 ./ So) * Uo'
+            decoder_mat = (1 / rescale) * Uo * Diagonal(So) * svdio.V[:, 1:trunc_val]
         end
 
         push!(get_encoder_mat(cc), encoder_mat)
         push!(get_decoder_mat(cc), decoder_mat)
 
-        # Note: To check CCA: 
+        # Note: To check CCA:
         # u = in_encoder * (in_data .- mean(in_data, dims=2))
         # v = out_encoder * (out_data .- mean(out_data, dims=2))
-        # u * u' = v * v' = I, 
-        # v * u' = u * v' = Diagonal(svdio.S[1:trunc_val])
+        # cov(u; dims=2) = cov(v; dims=2) = I  (canonical variates have unit sample variance)
+        # cov(u, v)-style cross term v * u' / (n_samples - 1) = u * v' / (n_samples - 1)
+        #   = Diagonal(svdio.S[1:trunc_val])
     end
 end
 

--- a/src/Utilities/decorrelator.jl
+++ b/src/Utilities/decorrelator.jl
@@ -166,6 +166,14 @@ get_encoder_mat(dd::Decorrelator) = dd.encoder_mat
 """
 $(TYPEDSIGNATURES)
 
+Returns `true` if `dd` has already been fit to data (and so `initialize_processor!` on it
+is a no-op).
+"""
+is_initialized(dd::Decorrelator) = !isempty(get_encoder_mat(dd))
+
+"""
+$(TYPEDSIGNATURES)
+
 returns the `decoder_mat` field of the `Decorrelator`.
 """
 get_decoder_mat(dd::Decorrelator) = dd.decoder_mat

--- a/src/Utilities/decorrelator.jl
+++ b/src/Utilities/decorrelator.jl
@@ -75,7 +75,7 @@ Constructs the `Decorrelator` struct. Users can add optional keyword arguments:
   - `"combined"`, sums the `"sample_cov"` and `"structure_mat"` matrices
 - `n_totvar_samples`[=`500`]: when retain_var < 1, number of samples to estimate the total variance for performing truncation.
 - `max_rank`[=`100`]: for `retain_var < 1`, the maximum dimension of subspace when using an the `tsvd` algorithm from `TSVD.jl`.
-- `psvd_kwargs` [= `(; rtol = 1e-3)`]: for `retain_var = 1`, the `psvd` algorithm from `LowRankApprox.jl` is used to decorrelate the space. kwargs can be passed in as a `NamedTuple`
+- `psvd_kwargs` [= `(; rtol = 1e-5)`]: for `retain_var = 1`, the `psvd` algorithm from `LowRankApprox.jl` is used to decorrelate the space. kwargs can be passed in as a `NamedTuple`
 """
 decorrelate(;
     retain_var::FT = Float64(1.0),
@@ -103,7 +103,7 @@ Constructs the `Decorrelator` struct, setting decorrelate_with = "sample_cov". E
 - `retain_var`[=`1.0`]: to project onto the leading singular vectors such that `retain_var` variance is retained
 - `n_totvar_samples`[=`500`]: when retain_var < 1, number of samples to estimate the total variance for performing truncation.
 - `max_rank`[=`100`]: for `retain_var < 1`, the maximum dimension of subspace when using an the `tsvd` algorithm from `TSVD.jl`.
-- `psvd_kwargs` [= `(; rtol = 1e-3)`]: for `retain_var = 1`, the `psvd` algorithm from `LowRankApprox.jl` is used to decorrelate the space. kwargs can be passed in as a `NamedTuple`
+- `psvd_kwargs` [= `(; rtol = 1e-5)`]: for `retain_var = 1`, the `psvd` algorithm from `LowRankApprox.jl` is used to decorrelate the space. kwargs can be passed in as a `NamedTuple`
 """
 decorrelate_sample_cov(;
     retain_var::FT = Float64(1.0),
@@ -284,23 +284,28 @@ function initialize_processor!(
             if ret_var < 1.0
                 # tsvd option
 
-                norm_sq_approx = zeros(n_norm_compute)
+                # Hutchinson trace estimator: tr(C) = E[zᵀCz] for z with iid mean-0, var-1
+                # entries. This matches the small-matrix branch's variance-fraction criterion
+                # (Σσᵢ = tr(C)) - a Frobenius-norm estimate (Σσᵢ² = ‖C‖²_F) is a DIFFERENT
+                # quantity and over-weights leading modes, truncating earlier than the stated
+                # `retain_var` variance fraction.
+                trace_approx = zeros(n_norm_compute)
                 for i in 1:n_norm_compute
-                    # approximate frobenius norm^2 (= sum of s.v.^2 = total variance)
-                    norm_sq_approx[i] = norm_linear_map(decorrelation_map, n_eval = n_totvar_samples)^2
+                    z = randn(size(decorrelation_map, 1))
+                    trace_approx[i] = dot(z, decorrelation_map * z)
                 end
-                @info "relative error of total variance $(std(norm_sq_approx)/mean(norm_sq_approx))"
-                retain_var_max = 1 - std(norm_sq_approx) / mean(norm_sq_approx)
+                @info "relative error of total variance $(std(trace_approx)/mean(trace_approx))"
+                retain_var_max = 1 - std(trace_approx) / mean(trace_approx)
 
                 ret_var_tmp = min(ret_var, retain_var_max)
 
                 for rk in 1:max_rank
                     _, Stmp, Vtmp = tsvd(decorrelation_map, rk)
-                    retain_var_current = sum(Stmp .^ 2) / (retain_var_max * mean(norm_sq_approx))
+                    retain_var_current = sum(Stmp) / (retain_var_max * mean(trace_approx))
                     if retain_var_current > ret_var_tmp
                         push!(S, Stmp)
                         push!(Vt, Vtmp')
-                        @info "    truncating at $(rk)/$(size(data,1)) retaining $(retain_var_current*100)% (+/-$(100*std(norm_sq_approx)/mean(norm_sq_approx)))% of the variance of the structure matrix"
+                        @info "    truncating at $(rk)/$(size(data,1)) retaining $(retain_var_current*100)% (+/-$(100*std(trace_approx)/mean(trace_approx)))% of the variance of the structure matrix"
                         break
                     end
                     if rk == max_rank

--- a/src/Utilities/elementwise_scaler.jl
+++ b/src/Utilities/elementwise_scaler.jl
@@ -198,6 +198,12 @@ function initialize_processor!(es::ElementwiseScaler, data::MM) where {MM <: Abs
         T = get_type(es)
         initialize_processor!(es, data, T)
 
+        scale = get_scale(es)
+        if any(iszero, scale)
+            @warn "ElementwiseScaler: $(count(iszero, scale)) constant data dimension(s) detected; using scale = 1 for those dimensions."
+            scale .= map(s -> iszero(s) ? one(s) : s, scale)
+        end
+
         # we explicitly make the encoder/decoder maps
         data_encoder_map = LinearMap(
             x -> (x .- get_shift(es)) ./ get_scale(es), # Ax

--- a/src/Utilities/elementwise_scaler.jl
+++ b/src/Utilities/elementwise_scaler.jl
@@ -110,6 +110,14 @@ get_shift(es::ElementwiseScaler) = es.shift
 """
 $(TYPEDSIGNATURES)
 
+Returns `true` if `es` has already been fit to data (and so `initialize_processor!` on it
+is a no-op).
+"""
+is_initialized(es::ElementwiseScaler) = !isempty(get_shift(es))
+
+"""
+$(TYPEDSIGNATURES)
+
 Gets the `scale` field of the `ElementwiseScaler`
 """
 get_scale(es::ElementwiseScaler) = es.scale

--- a/src/Utilities/likelihood_informed.jl
+++ b/src/Utilities/likelihood_informed.jl
@@ -53,6 +53,14 @@ end
 
 get_encoder_mat(li::LikelihoodInformed) = li.encoder_mat
 get_decoder_mat(li::LikelihoodInformed) = li.decoder_mat
+
+"""
+$(TYPEDSIGNATURES)
+
+Returns `true` if `li` has already been fit to data (and so `initialize_processor!` on it
+is a no-op).
+"""
+is_initialized(li::LikelihoodInformed) = !isempty(get_encoder_mat(li))
 get_data_mean(li::LikelihoodInformed) = li.data_mean
 
 """

--- a/src/Utilities/likelihood_informed.jl
+++ b/src/Utilities/likelihood_informed.jl
@@ -83,7 +83,7 @@ function initialize_processor!(
     li::LikelihoodInformed,
     in_data::MM,
     out_data::MM,
-    ::Dict{Symbol, SM1},
+    input_structure_matrices::Dict{Symbol, SM1},
     output_structure_matrices::Dict{Symbol, SM2},
     input_structure_vectors::Dict{Symbol, SV1},
     output_structure_vectors::Dict{Symbol, SV2},
@@ -126,6 +126,15 @@ function initialize_processor!(
             false
         end
         noise_cov_inv = inv(obs_noise_cov)
+
+        if apply_to == "in"
+            input_whitened =
+                haskey(input_structure_matrices, :prior_cov) &&
+                isapprox(Matrix(get_structure_mat(input_structure_matrices, :prior_cov)), I, atol = 1e-8)
+            if !input_whitened
+                @warn "LikelihoodInformed input-space diagnostic assumes whitened inputs (prior covariance ≈ I). Consider decorrelating inputs (e.g. decorrelate_structure_mat on the prior covariance) before likelihood_informed, otherwise the recovered subspace is not the prior-preconditioned LIS."
+            end
+        end
 
         li.apply_to = apply_to
 
@@ -248,8 +257,8 @@ function initialize_processor!(
                 alpha_weight[1:(end - 1)] .+= Δa ./ 2
                 alpha_weight[2:end] .+= Δa ./ 2
                 alpha_weight ./= sum(alpha_weight)
-                diagnostic_mat = sum(alpha_weight[i] * diagnostic_mats[iter] for (i, iter) in enumerate(iters[2:end]))
-                samples_mean = sum(alpha_weight[i] * samples_means[iter] for (i, iter) in enumerate(iters[2:end]))
+                diagnostic_mat = sum(alpha_weight[i] * diagnostic_mats[iter] for (i, iter) in enumerate(iters))
+                samples_mean = sum(alpha_weight[i] * samples_means[iter] for (i, iter) in enumerate(iters))
             else
                 diagnostic_mat = diagnostic_mats[iters[1]]
                 samples_mean = samples_means[iters[1]]
@@ -284,7 +293,7 @@ function initialize_processor!(
                 diagnostic_f = (x, Vs) -> sum(w * f(x, Vs) for (f, w) in zip(diagnostic_fs, alpha_weight))
                 diagnostic_egrad =
                     (x, Vs) -> sum(w * egrad(x, Vs) for (egrad, w) in zip(diagnostic_egrads, alpha_weight))
-                samples_mean = sum(alpha_weight[i] * samples_means[iter] for (i, iter) in enumerate(iters[2:end]))
+                samples_mean = sum(alpha_weight[i] * samples_means[iter] for (i, iter) in enumerate(iters))
 
                 # return:
                 diagnostic_f, diagnostic_egrad, samples_mean

--- a/src/show.jl
+++ b/src/show.jl
@@ -335,56 +335,60 @@ end
 
 # RWMetropolisHastings
 
-function Base.show(io::IO, x::RWMetropolisHastings{PT, ADT}) where {PT, ADT <: AutodiffProtocol}
-    print(io, "RWMetropolisHastings{$(nameof(ADT))}")
+function Base.show(io::IO, x::RWMetropolisHastings{LT, ADT}) where {LT, ADT <: AutodiffProtocol}
+    print(io, "RWMetropolisHastings{$(nameof(ADT))} (dim=$(size(x.cholesky_L, 1)))")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::RWMetropolisHastings{PT, ADT}) where {PT, ADT <: AutodiffProtocol}
+function Base.show(io::IO, ::MIME"text/plain", x::RWMetropolisHastings{LT, ADT}) where {LT, ADT <: AutodiffProtocol}
     if get(io, :compact, false)
         show(io, x)
     else
-        print(io, "RWMetropolisHastings{$(nameof(ADT))}")
+        print(io, "RWMetropolisHastings{$(nameof(ADT))} (dim=$(size(x.cholesky_L, 1)))")
     end
 end
 
-function Base.summary(io::IO, x::RWMetropolisHastings{PT, ADT}) where {PT, ADT <: AutodiffProtocol}
-    print(io, "RWMetropolisHastings{$(nameof(ADT))}")
+function Base.summary(io::IO, x::RWMetropolisHastings{LT, ADT}) where {LT, ADT <: AutodiffProtocol}
+    print(io, "RWMetropolisHastings{$(nameof(ADT))} (dim=$(size(x.cholesky_L, 1)))")
 end
 
 # pCNMetropolisHastings
 
-function Base.show(io::IO, x::pCNMetropolisHastings{D, T}) where {D, T <: AutodiffProtocol}
-    print(io, "pCNMetropolisHastings{$(nameof(T))}")
+function Base.show(io::IO, x::pCNMetropolisHastings{VT, LT, T}) where {VT, LT, T <: AutodiffProtocol}
+    print(io, "pCNMetropolisHastings{$(nameof(T))} (dim=$(size(x.cholesky_L, 1)))")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::pCNMetropolisHastings{D, T}) where {D, T <: AutodiffProtocol}
+function Base.show(
+    io::IO,
+    ::MIME"text/plain",
+    x::pCNMetropolisHastings{VT, LT, T},
+) where {VT, LT, T <: AutodiffProtocol}
     if get(io, :compact, false)
         show(io, x)
     else
-        print(io, "pCNMetropolisHastings{$(nameof(T))}")
+        print(io, "pCNMetropolisHastings{$(nameof(T))} (dim=$(size(x.cholesky_L, 1)))")
     end
 end
 
-function Base.summary(io::IO, x::pCNMetropolisHastings{D, T}) where {D, T <: AutodiffProtocol}
-    print(io, "pCNMetropolisHastings{$(nameof(T))}")
+function Base.summary(io::IO, x::pCNMetropolisHastings{VT, LT, T}) where {VT, LT, T <: AutodiffProtocol}
+    print(io, "pCNMetropolisHastings{$(nameof(T))} (dim=$(size(x.cholesky_L, 1)))")
 end
 
 # BarkerMetropolisHastings
 
-function Base.show(io::IO, x::BarkerMetropolisHastings{D, T}) where {D, T <: AutodiffProtocol}
-    print(io, "BarkerMetropolisHastings{$(nameof(T))}")
+function Base.show(io::IO, x::BarkerMetropolisHastings{LT, T}) where {LT, T <: AutodiffProtocol}
+    print(io, "BarkerMetropolisHastings{$(nameof(T))} (dim=$(size(x.cholesky_L, 1)))")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::BarkerMetropolisHastings{D, T}) where {D, T <: AutodiffProtocol}
+function Base.show(io::IO, ::MIME"text/plain", x::BarkerMetropolisHastings{LT, T}) where {LT, T <: AutodiffProtocol}
     if get(io, :compact, false)
         show(io, x)
     else
-        print(io, "BarkerMetropolisHastings{$(nameof(T))}")
+        print(io, "BarkerMetropolisHastings{$(nameof(T))} (dim=$(size(x.cholesky_L, 1)))")
     end
 end
 
-function Base.summary(io::IO, x::BarkerMetropolisHastings{D, T}) where {D, T <: AutodiffProtocol}
-    print(io, "BarkerMetropolisHastings{$(nameof(T))}")
+function Base.summary(io::IO, x::BarkerMetropolisHastings{LT, T}) where {LT, T <: AutodiffProtocol}
+    print(io, "BarkerMetropolisHastings{$(nameof(T))} (dim=$(size(x.cholesky_L, 1)))")
 end
 
 # MCMCWrapper

--- a/test/Emulator/runtests.jl
+++ b/test/Emulator/runtests.jl
@@ -76,6 +76,9 @@ struct MLTester <: Emulators.MachineLearningTool end
     @test isapprox(norm(decoded_mat - x), 0, atol = tol * p * m)
     @test isapprox(norm(decoded_I - 1.0 * I), 0, atol = tol * d * d)
 
+    # m8: unrecognized `encode` values must throw, not silently behave as `encode = nothing`
+    @test_throws ArgumentError EM.predict(em, x; encode = "In")
+
     # test obs_noise_cov   (check the warning at the start)
     @test_logs (:warn,) (:info,) (:warn,) (:info,) (:warn,) Emulator(gp, io_pairs, obs_noise_cov = Σ)
     @test_logs (:warn,) (:info,) (:warn,) (:info,) (:warn,) Emulator(
@@ -150,6 +153,9 @@ end
     end
     # Resolution test (Step 7c): passing already-encoded inputs with encode = "in" must not throw
     @test EM.predict(fmw, encode_data(fmw, x_test, "in"); encode = "in") isa Tuple
+
+    # m8: unrecognized `encode` values must throw, not silently behave as `encode = nothing`
+    @test_throws ArgumentError EM.predict(fmw, x_test; encode = "In")
 
     # with out enc.
     fmw = forward_map_wrapper(G, prior, io_pairs, encoder_kwargs = (; obs_noise_cov = Σ))

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -646,7 +646,13 @@ end
 
         noise_injector = create_noise_injector(lossless_sch, prior_1d, 0.0, 0.5)
 
-
+        # m20: `decode_and_add_noise` must be reproducible under a shared rng, and
+        # independent of the global RNG state
+        rng1 = MersenneTwister(24)
+        rng2 = MersenneTwister(24)
+        samples_a = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.15, ni_scaling; rng = rng1)
+        samples_b = decode_and_add_noise(lossy_sch, enc_samples, prior_mv, 0.15, ni_scaling; rng = rng2)
+        @test samples_a == samples_b
     end
 
 

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -849,13 +849,14 @@ end
             # sqrt(tr(Var)/n_draws): RW's Var = stepsize²C gives 5·RMS ≈ 0.053; pCN's Var =
             # (1-ρ²)C gives 5·RMS ≈ 0.067 (both at stepsize=0.5, n_draws=10_000).
             #
-            # pCN is constructed with a genuinely NON-zero prior mean `m` here (regression test
-            # for the C1 secondary defect: pCN previously always contracted toward 0 regardless of
-            # the encoded prior's actual mean). If `transition_kernel` silently ignored `m` and
-            # contracted toward 0 instead, this test would fail: the analytic reference below is
+            # pCN is constructed with a genuinely NON-zero, fixed (not rng-drawn, so the gap below
+            # is guaranteed rather than incidental) prior mean `m` here (regression test for the C1
+            # secondary defect: pCN previously always contracted toward 0 regardless of the encoded
+            # prior's actual mean). If `transition_kernel` silently ignored `m` and contracted
+            # toward 0 instead, this test would fail: the analytic reference below is
             # `m + ρ(a - m)`, which only coincides with `ρ*a` when `m` happens to be 0.
             rw = MCMC.RWMetropolisHastings{typeof(L), MCMC.GradFreeProtocol}(L)
-            m = randn(rng, n)
+            m = fill(3.0, n)
             pcn = MCMC.pCNMetropolisHastings{typeof(m), typeof(L), MCMC.GradFreeProtocol}(m, L)
             state = MCMC.MCMCState(a, 0.0, true)
             n_draws = 10_000
@@ -865,7 +866,8 @@ end
             ρ = (1 - 0.5 / 4) / (1 + 0.5 / 4)
             @test isapprox(mean(pcn_draws), m .+ ρ .* (a .- m); atol = 0.07)
             # Sanity: with this m, the (wrong) zero-mean prediction ρ*a is nowhere near the
-            # analytic mean, so this test could not have passed against the pre-fix formula.
+            # analytic mean (gap = norm(m)*(1-ρ) ≈ 1.15, deterministic since m is fixed), so this
+            # test could not have passed against the pre-fix formula.
             @test norm((m .+ ρ .* (a .- m)) .- (ρ .* a)) > 0.5
         end
 

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -814,7 +814,7 @@ end
         @testset "pCN: Hastings term exactly cancels the prior ratio" begin
             # This is the core bug: reverse - forward must equal logprior(a) - logprior(b)
             # for every stepsize (every ρ), not silently 0.
-            pcn = MCMC.pCNMetropolisHastings{typeof(L), MCMC.GradFreeProtocol}(L)
+            pcn = MCMC.pCNMetropolisHastings{typeof(zeros(n)), typeof(L), MCMC.GradFreeProtocol}(zeros(n), L)
             prev_state = MCMC.MCMCState(a, 0.0, true)
             for s in (0.05, 0.5, 1.5, 3.9)
                 hastings = AdvancedMH.logratio_proposal_density(pcn, dummy_model, prev_state, b; stepsize = s)
@@ -828,7 +828,7 @@ end
             # (loglik cancels trivially, and the Hastings term cancels the prior ratio). Under
             # the pre-fix code (Hastings term silently 0), this would instead fluctuate with the
             # prior ratio and cause spurious rejections.
-            pcn = MCMC.pCNMetropolisHastings{typeof(L), MCMC.GradFreeProtocol}(L)
+            pcn = MCMC.pCNMetropolisHastings{typeof(zeros(n)), typeof(L), MCMC.GradFreeProtocol}(zeros(n), L)
             flat_model = AdvancedMH.DensityModel(θ -> logpdf(prior_dist, θ))
             θ0 = zeros(n)
             state = MCMC.MCMCState(θ0, AdvancedMH.logdensity(flat_model, θ0), true)
@@ -848,15 +848,25 @@ end
             # enough to catch a real scaling bug), via the Monte Carlo mean's norm-error RMS
             # sqrt(tr(Var)/n_draws): RW's Var = stepsize²C gives 5·RMS ≈ 0.053; pCN's Var =
             # (1-ρ²)C gives 5·RMS ≈ 0.067 (both at stepsize=0.5, n_draws=10_000).
+            #
+            # pCN is constructed with a genuinely NON-zero prior mean `m` here (regression test
+            # for the C1 secondary defect: pCN previously always contracted toward 0 regardless of
+            # the encoded prior's actual mean). If `transition_kernel` silently ignored `m` and
+            # contracted toward 0 instead, this test would fail: the analytic reference below is
+            # `m + ρ(a - m)`, which only coincides with `ρ*a` when `m` happens to be 0.
             rw = MCMC.RWMetropolisHastings{typeof(L), MCMC.GradFreeProtocol}(L)
-            pcn = MCMC.pCNMetropolisHastings{typeof(L), MCMC.GradFreeProtocol}(L)
+            m = randn(rng, n)
+            pcn = MCMC.pCNMetropolisHastings{typeof(m), typeof(L), MCMC.GradFreeProtocol}(m, L)
             state = MCMC.MCMCState(a, 0.0, true)
             n_draws = 10_000
             rw_draws = [AdvancedMH.propose(rng, rw, dummy_model, state; stepsize = 0.5) for _ in 1:n_draws]
             pcn_draws = [AdvancedMH.propose(rng, pcn, dummy_model, state; stepsize = 0.5) for _ in 1:n_draws]
             @test isapprox(mean(rw_draws), a; atol = 0.06)
             ρ = (1 - 0.5 / 4) / (1 + 0.5 / 4)
-            @test isapprox(mean(pcn_draws), ρ .* a; atol = 0.07)
+            @test isapprox(mean(pcn_draws), m .+ ρ .* (a .- m); atol = 0.07)
+            # Sanity: with this m, the (wrong) zero-mean prediction ρ*a is nowhere near the
+            # analytic mean, so this test could not have passed against the pre-fix formula.
+            @test norm((m .+ ρ .* (a .- m)) .- (ρ .* a)) > 0.5
         end
 
         @testset "Barker: transition density matches closed-form gradient formula" begin
@@ -960,6 +970,44 @@ end
             draws = zeros(n_samples)
             for i in 1:n_samples
                 state, _ = AbstractMCMC.step(rng_local, model, barker, state; stepsize = stepsize)
+                draws[i] = state.params[1]
+            end
+            @test isapprox(mean(draws), post_mean; rtol = 0.05)
+            @test isapprox(var(draws), post_var; rtol = 0.05)
+        end
+
+        @testset "pCN: recovers the exact 1D conjugate-Gaussian posterior for a NON-zero-mean prior (regression for C1 secondary defect)" begin
+            # Full-sampler-level regression test for C1's secondary defect: pCN previously
+            # contracted its proposal toward 0 regardless of the prior's actual mean, which is
+            # only correct in the special case of a zero-mean prior. Here the prior mean m=2 is
+            # deliberately non-zero, isolating exactly this defect (everything else matches the
+            # already-verified Barker keystone test above: same τ², σ², y_obs).
+            # Prior θ ~ N(m, τ²), single observation y ~ N(θ, σ²): posterior mean = V*(m/τ² + y/σ²),
+            # posterior var V = τ²σ²/(τ²+σ²), with V = 1/3, mean = 7/3 exactly for these numbers.
+            τ2 = 1.0
+            σ2 = 0.5
+            m = 2.0
+            y_obs = 2.5
+            post_var = (τ2 * σ2) / (τ2 + σ2)
+            post_mean = post_var * (m / τ2 + y_obs / σ2)
+            @test isapprox(post_mean, 7.0 / 3.0; atol = 1e-12)
+            @test isapprox(post_var, 1.0 / 3.0; atol = 1e-12)
+
+            target_logdensity(θ) = logpdf(Normal(m, sqrt(τ2)), θ[1]) + logpdf(Normal(θ[1], sqrt(σ2)), y_obs)
+            model = AdvancedMH.DensityModel(target_logdensity)
+            L1 = reshape([sqrt(τ2)], 1, 1)
+            pcn = MCMC.pCNMetropolisHastings{typeof([m]), typeof(L1), MCMC.GradFreeProtocol}([m], L1)
+
+            rng_local = Random.MersenneTwister(2025)
+            stepsize = 0.7
+            state = MCMC.MCMCState([m], AdvancedMH.logdensity(model, [m]), true)
+            for _ in 1:1000
+                state, _ = AbstractMCMC.step(rng_local, model, pcn, state; stepsize = stepsize)
+            end
+            n_samples = 20_000
+            draws = zeros(n_samples)
+            for i in 1:n_samples
+                state, _ = AbstractMCMC.step(rng_local, model, pcn, state; stepsize = stepsize)
                 draws[i] = state.params[1]
             end
             @test isapprox(mean(draws), post_mean; rtol = 0.05)

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -548,4 +548,52 @@ rng = Random.MersenneTwister(seed)
 
     end
 
+    # G3 regression test: a constant input (or output) dimension must not produce Inf/NaN
+    # scales (and hence NaN/PosDefException deep in the hyperparameter prior); build_models!
+    # should warn and fall back to scale = 1 for the degenerate dimension(s) instead.
+    @testset "Scalar/VectorRandomFeatureInterface: degenerate (constant) input dimension" begin
+        rng_deg = Random.MersenneTwister(20270728)
+        input_dim_deg = 2
+        output_dim_deg = 1
+        n_deg = 30
+        x1_deg = 2.0 * π * rand(rng_deg, n_deg)
+        x_deg = vcat(reshape(x1_deg, 1, n_deg), fill(3.0, 1, n_deg)) # 2nd input dimension constant
+        y_deg = reshape(sin.(x1_deg) + 0.01 * randn(rng_deg, n_deg), 1, n_deg)
+        iopairs_deg = PairedDataContainer(x_deg, y_deg, data_are_columns = true)
+
+        small_opts = Dict("n_cross_val_sets" => 0, "n_iteration" => 1, "n_ensemble" => 10, "n_features_opt" => 10)
+
+        # `encoder_schedule = []` disables the default input decorrelation, which would
+        # otherwise whiten-and-truncate the constant dimension away before `build_models!`
+        # ever sees it - bypassing it here so the guard added inside `build_models!` itself
+        # (for users who configure no input decorrelation) is what's actually exercised.
+        srfi_deg = ScalarRandomFeatureInterface(10, input_dim_deg; rng = rng_deg, optimizer_options = small_opts)
+        em_srfi_deg = @test_logs (:warn, r"constant input dimension") match_mode = :any Emulator(
+            srfi_deg,
+            iopairs_deg;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = 0.01 * I),
+        )
+        μ_s_deg, σ2_s_deg = Emulators.predict(em_srfi_deg, x_deg)
+        @test all(isfinite, μ_s_deg)
+        @test all(isfinite, σ2_s_deg)
+
+        vrfi_deg = VectorRandomFeatureInterface(
+            10,
+            input_dim_deg,
+            output_dim_deg;
+            rng = rng_deg,
+            optimizer_options = small_opts,
+        )
+        em_vrfi_deg = @test_logs (:warn, r"constant input dimension") match_mode = :any Emulator(
+            vrfi_deg,
+            iopairs_deg;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = 0.01 * I),
+        )
+        μ_v_deg, σ2_v_deg = Emulators.predict(em_vrfi_deg, x_deg)
+        @test all(isfinite, μ_v_deg)
+        @test all(isfinite, σ2_v_deg)
+    end
+
 end

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -596,4 +596,51 @@ rng = Random.MersenneTwister(seed)
         @test all(isfinite, σ2_v_deg)
     end
 
+    # G3 regression test, output side: a constant output dimension must not produce Inf/NaN
+    # scales (and hence NaN/PosDefException deep in the hyperparameter prior); build_models!
+    # should warn and fall back to scale = 1 for the degenerate output dimension(s) instead.
+    @testset "Scalar/VectorRandomFeatureInterface: degenerate (constant) output dimension" begin
+        rng_deg = Random.MersenneTwister(20270728)
+        input_dim_deg = 1
+        output_dim_deg = 1
+        n_deg = 30
+        x_deg = reshape(2.0 * π * rand(rng_deg, n_deg), 1, n_deg)
+        y_deg = fill(3.0, 1, n_deg) # output constant for every sample
+        iopairs_deg = PairedDataContainer(x_deg, y_deg, data_are_columns = true)
+
+        small_opts = Dict("n_cross_val_sets" => 0, "n_iteration" => 1, "n_ensemble" => 10, "n_features_opt" => 10)
+
+        # `encoder_schedule = []` disables the default output decorrelation, which would
+        # otherwise whiten-and-truncate the constant output away before `build_models!`
+        # ever sees it - bypassing it here so the guard added inside `build_models!` itself
+        # (for users who configure no output decorrelation) is what's actually exercised.
+        srfi_deg_out = ScalarRandomFeatureInterface(10, input_dim_deg; rng = rng_deg, optimizer_options = small_opts)
+        em_srfi_deg_out = @test_logs (:warn, r"constant output detected") match_mode = :any Emulator(
+            srfi_deg_out,
+            iopairs_deg;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = 0.01 * I),
+        )
+        μ_s_deg_out, σ2_s_deg_out = Emulators.predict(em_srfi_deg_out, x_deg)
+        @test all(isfinite, μ_s_deg_out)
+        @test all(isfinite, σ2_s_deg_out)
+
+        vrfi_deg_out = VectorRandomFeatureInterface(
+            10,
+            input_dim_deg,
+            output_dim_deg;
+            rng = rng_deg,
+            optimizer_options = small_opts,
+        )
+        em_vrfi_deg_out = @test_logs (:warn, r"constant output dimension") match_mode = :any Emulator(
+            vrfi_deg_out,
+            iopairs_deg;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = 0.01 * I),
+        )
+        μ_v_deg_out, σ2_v_deg_out = Emulators.predict(em_vrfi_deg_out, x_deg)
+        @test all(isfinite, μ_v_deg_out)
+        @test all(isfinite, σ2_v_deg_out)
+    end
+
 end

--- a/test/Show/runtests.jl
+++ b/test/Show/runtests.jl
@@ -219,8 +219,8 @@ const MCMC = MarkovChainMonteCarlo
     # ── MarkovChainMonteCarlo ──────────────────────────────────────────────────
 
     @testset "RWMetropolisHastings" begin
-        prop = AdvancedMH.RandomWalkProposal(MvNormal(zeros(2), I(2)))
-        rw = MCMC.RWMetropolisHastings{typeof(prop), GradFreeProtocol}(prop)
+        L = cholesky(Symmetric(Matrix{Float64}(I, 2, 2))).L
+        rw = MCMC.RWMetropolisHastings{typeof(L), GradFreeProtocol}(L)
         out = sprint(show, MIME("text/plain"), rw)
         @test occursin("RWMetropolisHastings", out)
         @test count(==('\n'), out) <= 10
@@ -235,8 +235,9 @@ const MCMC = MarkovChainMonteCarlo
     end
 
     @testset "pCNMetropolisHastings" begin
-        prop = AdvancedMH.RandomWalkProposal(MvNormal(zeros(2), I(2)))
-        pcn = MCMC.pCNMetropolisHastings{typeof(prop), GradFreeProtocol}(prop)
+        L = cholesky(Symmetric(Matrix{Float64}(I, 2, 2))).L
+        m = zeros(2)
+        pcn = MCMC.pCNMetropolisHastings{typeof(m), typeof(L), GradFreeProtocol}(m, L)
         out = sprint(show, MIME("text/plain"), pcn)
         @test occursin("pCNMetropolisHastings", out)
         @test count(==('\n'), out) <= 10
@@ -251,8 +252,8 @@ const MCMC = MarkovChainMonteCarlo
     end
 
     @testset "BarkerMetropolisHastings" begin
-        prop = AdvancedMH.RandomWalkProposal(MvNormal(zeros(2), I(2)))
-        barkr = MCMC.BarkerMetropolisHastings{typeof(prop), ForwardDiffProtocol}(prop)
+        L = cholesky(Symmetric(Matrix{Float64}(I, 2, 2))).L
+        barkr = MCMC.BarkerMetropolisHastings{typeof(L), ForwardDiffProtocol}(L)
         out = sprint(show, MIME("text/plain"), barkr)
         @test occursin("BarkerMetropolisHastings", out)
         @test count(==('\n'), out) <= 10
@@ -270,8 +271,8 @@ const MCMC = MarkovChainMonteCarlo
         prior = constrained_gaussian("x", 0.0, 1.0, -Inf, Inf; repeats = 2)
         obs = [rand(2) for _ in 1:3]
         log_post = AdvancedMH.DensityModel(x -> -0.5 * sum(x .^ 2))
-        prop = AdvancedMH.RandomWalkProposal(MvNormal(zeros(2), I(2)))
-        rw_sampler = MCMC.RWMetropolisHastings{typeof(prop), GradFreeProtocol}(prop)
+        L = cholesky(Symmetric(Matrix{Float64}(I, 2, 2))).L
+        rw_sampler = MCMC.RWMetropolisHastings{typeof(L), GradFreeProtocol}(L)
         mcmcw =
             MCMCWrapper{typeof(obs), typeof(obs), Vector{Any}}(prior, prior, obs, obs, log_post, rw_sampler, (;), [])
         out = sprint(show, MIME("text/plain"), mcmcw)

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -290,6 +290,110 @@ end
         @test contains(thrown.value.msg, "Float64")
     end
 
+    # M7 regression test: the composite-trapezoid weights over the α-path must be
+    # paired with their own node, not shifted by one (see full-code-review M7).
+    # Construction: for each of 3 nodes, samples_in is the fixed zero-mean basis
+    # [e1 -e1 e2 -e2] (population covariance 0.5*I), and samples_out = grad_it * samples_in
+    # exactly (no noise), so :linreg regression recovers grad_it exactly. With
+    # obs_noise_cov = I and observation y = 0, the per-node diagnostic matrix reduces
+    # exactly to M_it = (1-α)*G_it + 0.5*α²*G_it² where G_it = grad_it' * grad_it -
+    # this is an exact algebraic identity for this construction, not an approximation.
+    let
+        basis_in = [1.0 -1.0 0.0 0.0; 0.0 0.0 1.0 -1.0] # e1, -e1, e2, -e2 as columns
+        rot(θ) = [cos(θ) -sin(θ); sin(θ) cos(θ)]
+
+        Qs = [rot(0.0), rot(deg2rad(30.0)), rot(deg2rad(70.0))]
+        Ds = [Diagonal([3.0, 1.0]), Diagonal([2.0, 1.0]), Diagonal([2.5, 1.0])]
+        alphas_nodes = [0.0, 0.4, 1.0]
+        grads_it = [Ds[i] * Qs[i]' for i in 1:3]
+        Gs = [g' * g for g in grads_it]
+        Ms = [(1 - alphas_nodes[i]) * Gs[i] + 0.5 * alphas_nodes[i]^2 * Gs[i]^2 for i in 1:3]
+
+        weights_correct = [0.2, 0.5, 0.3] # composite trapezoid weights for alphas [0, 0.4, 1.0]
+        M_correct = sum(weights_correct[i] * Ms[i] for i in 1:3)
+
+        samples_out_it = [grads_it[i] * basis_in for i in 1:3]
+
+        li_m7 = likelihood_informed(retain_info = 1.0, iters = 1:3, grad_type = :linreg)
+        Utilities.initialize_processor!(
+            li_m7,
+            basis_in,
+            zeros(2, 4),
+            Dict(:prior_cov => Matrix{Float64}(I, 2, 2)), # whitened: keep this test focused on M7, not M8
+            Dict(:obs_noise_cov => Matrix{Float64}(I, 2, 2)),
+            Dict(:dt => alphas_nodes, :samples_in => [basis_in, basis_in, basis_in]),
+            Dict(:observation => [zeros(2)], :samples_out => samples_out_it),
+            "in",
+        )
+        encoder_mat_m7 = Matrix(get_encoder_mat(li_m7)[1])
+
+        # encoder_mat's rows are the eigenvectors of the diagnostic matrix the code actually
+        # combined: if weights are correctly aligned with nodes, they diagonalize M_correct.
+        off_diag_correct = encoder_mat_m7 * M_correct * encoder_mat_m7'
+        off_diag_correct -= Diagonal(off_diag_correct)
+        @test norm(off_diag_correct) < 1e-8
+
+        # sanity: the construction actually discriminates - the pre-fix (weight-shifted) combination
+        # does NOT get diagonalized by the same encoder, so this test could not have passed by accident.
+        M_buggy = weights_correct[1] * Ms[2] + weights_correct[2] * Ms[3]
+        off_diag_buggy = encoder_mat_m7 * M_buggy * encoder_mat_m7'
+        off_diag_buggy -= Diagonal(off_diag_buggy)
+        @test norm(off_diag_buggy) > 1e-3
+    end
+
+    # M8 regression test: LikelihoodInformed's input-space diagnostic silently assumed
+    # prior covariance ≈ I; it must now warn when apply_to == "in" and the input
+    # structure matrices' :prior_cov is missing or not ≈ I, and stay silent when it is.
+    let
+        rng_m8 = Random.MersenneTwister(1234)
+        in_dim8 = 3
+        out_dim8 = 2
+        in_data8 = randn(rng_m8, in_dim8, 5)
+        out_data8 = randn(rng_m8, out_dim8, 5)
+        input_vecs8 = Dict(:dt => [0.0])
+        output_mats8 = Dict(:obs_noise_cov => Matrix{Float64}(I, out_dim8, out_dim8))
+        output_vecs8 = Dict{Symbol, Utilities.StructureVector}()
+
+        # non-identity prior_cov => warns (min_level=Warn filters the unrelated @info emitted
+        # at the start of initialize_processor!; the single remaining log must match)
+        non_id_prior = [2.0 0.3 0.0; 0.3 1.5 0.0; 0.0 0.0 1.0]
+        @test_logs (:warn, r"assumes whitened inputs") min_level = Base.CoreLogging.Warn Utilities.initialize_processor!(
+            likelihood_informed(retain_info = 1.0, iters = [1], grad_type = :linreg),
+            in_data8,
+            out_data8,
+            Dict(:prior_cov => non_id_prior),
+            output_mats8,
+            input_vecs8,
+            output_vecs8,
+            "in",
+        )
+
+        # missing :prior_cov key => warns
+        @test_logs (:warn, r"assumes whitened inputs") min_level = Base.CoreLogging.Warn Utilities.initialize_processor!(
+            likelihood_informed(retain_info = 1.0, iters = [1], grad_type = :linreg),
+            in_data8,
+            out_data8,
+            Dict{Symbol, Utilities.StructureMatrix}(),
+            output_mats8,
+            input_vecs8,
+            output_vecs8,
+            "in",
+        )
+
+        # identity prior_cov => no warning (zero patterns + min_level=Warn: passes iff no
+        # Warn-or-above log is emitted; unrelated @info is filtered out by min_level)
+        @test_logs min_level = Base.CoreLogging.Warn Utilities.initialize_processor!(
+            likelihood_informed(retain_info = 1.0, iters = [1], grad_type = :linreg),
+            in_data8,
+            out_data8,
+            Dict(:prior_cov => Matrix{Float64}(I, in_dim8, in_dim8)),
+            output_mats8,
+            input_vecs8,
+            output_vecs8,
+            "in",
+        )
+    end
+
     # test equalities
     cc = canonical_correlation()
     cc_copy = canonical_correlation()

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -172,6 +172,13 @@ end
     # Resolution test (Step 7c): replacing λI with Diagonal(fill(λ, d)) must not throw
     @test size(create_compact_linear_map(Diagonal(fill(3.0, 3)))) == (3, 3)
 
+    # h12: an unsupported block type must throw a clear ArgumentError, not silently
+    # produce a zero-size block (which previously surfaced as a distant BoundsError)
+    let thrown = @test_throws ArgumentError create_compact_linear_map([1])
+        @test contains(thrown.value.msg, "unsupported")
+        @test contains(thrown.value.msg, "Int64")
+    end
+
     for svd_type in ["psvd", "tsvd"]
         psvd_kwargs = (; rtol = 1e-3) # make very small for testing
         tsvd_max_rank = 30 # often only stable small ranks
@@ -289,6 +296,15 @@ end
         @test contains(thrown.value.msg, "eltype(iters)")
         @test contains(thrown.value.msg, "Float64")
     end
+
+    # h12: `==` across different DataContainerProcessor/PairedDataContainerProcessor
+    # concrete types must return false, not throw a FieldError from mismatched fieldnames
+    QQ2 = ElementwiseScaler{QuartileScaling, Vector{Int}, Vector, Vector, Vector, Vector}([1], [2], [3], [4], [5], [6])
+    @test QQ == QQ2
+    @test !(QQ == DD)
+    @test !(DD == QQ)
+    @test !(cc3 == ll3)
+    @test !(ll3 == cc3)
 
     # M7 regression test: the composite-trapezoid weights over the α-path must be
     # paired with their own node, not shifted by one (see full-code-review M7).

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -588,7 +588,10 @@ end
             # Paired data processor reduction:
             if name == "canonical-correlation"
                 @test dimm == min(rank(get_inputs(io_pairs)), rank(get_outputs(io_pairs)))
-                @test isapprox(norm(enc_dat * enc_dat' - I), 0.0, atol = tol * dimm^2) # test in or out orthogonality
+                # canonical variates have sample covariance ≈ I (not energy-normalized u*u' ≈ I;
+                # rescaled by √(n_samples-1) in initialize_processor! so this matches every
+                # sibling processor's convention)
+                @test isapprox(norm(pop_cov - I), 0.0, atol = tol * dimm^2) # test in or out orthogonality
 
                 # check cross-orthogonality is diagonal (nb this test will be duplicate)
                 enc_in = get_inputs(encoded_io_pairs)
@@ -617,6 +620,33 @@ end
 
         end
 
+    end
+
+    # G3 regression test: CanonicalCorrelation must not blow up (Inf/NaN, or select the wrong
+    # in/out role) on rank-deficient (collinear-ensemble) data.
+    let
+        rng_deg = Random.MersenneTwister(2026)
+        in_dim_deg = 4
+        out_dim_deg = 3
+        samples_deg = 20
+        x_deg = randn(rng_deg, in_dim_deg - 1, samples_deg)
+        in_data_deg = vcat(x_deg, x_deg[1:1, :]) # duplicate the first row: rank(in_data_deg) == in_dim_deg - 1 == out_dim_deg
+        out_data_deg = randn(rng_deg, out_dim_deg, samples_deg)
+        io_pairs_deg = PairedDataContainer(in_data_deg, out_data_deg)
+
+        cc_deg = canonical_correlation()
+        enc_sch_deg = create_encoder_schedule((cc_deg, "in_and_out"))
+        (encoded_io_pairs_deg, _, _, _, _) = initialize_and_encode_with_schedule!(enc_sch_deg, io_pairs_deg)
+
+        @test all(isfinite, get_inputs(encoded_io_pairs_deg))
+        @test all(isfinite, get_outputs(encoded_io_pairs_deg))
+
+        # both sides have rank 3 == trunc_val here, so neither loses information: round-trip
+        # should be exact (up to numerical rank-truncation tolerance), for both "in" and "out".
+        dec_in_deg = decode_data(enc_sch_deg, get_inputs(encoded_io_pairs_deg), "in")
+        dec_out_deg = decode_data(enc_sch_deg, get_outputs(encoded_io_pairs_deg), "out")
+        @test isapprox(norm(dec_in_deg - in_data_deg), 0.0, atol = 1e-8 * samples_deg)
+        @test isapprox(norm(dec_out_deg - out_data_deg), 0.0, atol = 1e-8 * samples_deg)
     end
 
     # test retrieval of the affine components from the schedule

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -649,6 +649,27 @@ end
         @test isapprox(norm(dec_out_deg - out_data_deg), 0.0, atol = 1e-8 * samples_deg)
     end
 
+    # G3 regression test: ElementwiseScaler (ZScore/MinMax/Quartile) must not divide by a zero
+    # scale (constant data dimension) and must warn rather than silently producing NaN/Inf.
+    let
+        rng_deg = Random.MersenneTwister(2027)
+        dim_deg = 3
+        samples_deg = 10
+        data_deg = randn(rng_deg, dim_deg, samples_deg)
+        data_deg[2, :] .= 5.0 # constant row: std = 0, max-min = 0, IQR = 0
+
+        for scaler in (zscore_scale(), minmax_scale(), quartile_scale())
+            enc_sch_deg = create_encoder_schedule((scaler, "in"))
+            io_pairs_deg = PairedDataContainer(data_deg, data_deg)
+            (encoded_io_pairs_deg, _, _, _, _) =
+                @test_logs (:warn, r"constant data dimension") match_mode = :any initialize_and_encode_with_schedule!(
+                    enc_sch_deg,
+                    io_pairs_deg,
+                )
+            @test all(isfinite, get_inputs(encoded_io_pairs_deg))
+        end
+    end
+
     # test retrieval of the affine components from the schedule
     # nothing option
     enc1 = get_encoder_from_schedule([])

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -841,6 +841,48 @@ end
 
 end
 
+@testset "M6: encoder schedules do not share fitted processor state" begin
+    rng_m6 = Random.MersenneTwister(20260731)
+    dim_m6 = 3
+    samples_m6 = 30
+
+    builder_list = [(zscore_scale(), "in")] # one builder list, reused for two schedules
+
+    # (a) two schedules built from the SAME builder list must not alias the same processor
+    # instance, and must fit independently to their own data.
+    schA = create_encoder_schedule(builder_list)
+    schB = create_encoder_schedule(builder_list)
+    @test schA[1][1] !== schB[1][1]
+
+    data_meanA = zeros(dim_m6)
+    data_meanB = fill(50.0, dim_m6)
+    io_pairs_A = PairedDataContainer(data_meanA .+ randn(rng_m6, dim_m6, samples_m6), randn(rng_m6, 1, samples_m6))
+    io_pairs_B = PairedDataContainer(data_meanB .+ randn(rng_m6, dim_m6, samples_m6), randn(rng_m6, 1, samples_m6))
+
+    initialize_and_encode_with_schedule!(schA, io_pairs_A)
+    (encoded_io_pairs_B, _, _, _, _) = initialize_and_encode_with_schedule!(schB, io_pairs_B)
+
+    # schB fit on its own (mean-50) data, so its encoded data should be centered near 0 -
+    # if it had aliased/reused schA's (mean-0) statistics, this would instead center near 50.
+    @test isapprox(norm(mean(get_inputs(encoded_io_pairs_B), dims = 2)), 0.0, atol = 1e-8)
+
+    # (b) re-initializing an already-fitted schedule must warn, and must NOT refit (existing
+    # semantics preserved). Check this deterministically against the processor's own stored
+    # shift/scale (rather than an encoded-mean tolerance, which would be confounded by
+    # sampling noise in the new data) - they must be BIT-IDENTICAL before and after, since a
+    # refit would recompute them from the new (mean-50) data.
+    shift_before = copy(get_shift(schA[1][1]))
+    scale_before = copy(get_scale(schA[1][1]))
+    io_pairs_A2 = PairedDataContainer(data_meanB .+ randn(rng_m6, dim_m6, samples_m6), randn(rng_m6, 1, samples_m6))
+    @test_logs (:warn, r"already-initialized") match_mode = :any initialize_and_encode_with_schedule!(schA, io_pairs_A2)
+    @test get_shift(schA[1][1]) == shift_before
+    @test get_scale(schA[1][1]) == scale_before
+
+    # a fresh, never-initialized schedule must NOT warn.
+    sch_fresh = create_encoder_schedule(builder_list)
+    @test_logs min_level = Base.CoreLogging.Warn initialize_and_encode_with_schedule!(sch_fresh, io_pairs_A)
+end
+
 
 
 
@@ -1007,7 +1049,9 @@ end
         io_pairs_large;
         output_structure_mats = Dict{Symbol, Utilities.StructureMatrix}(:obs_noise_cov => C_large),
     )
-    achieved_rank_large = size(get_encoder_mat(dd_large)[1], 1)
+    # `create_encoder_schedule` deepcopies its processor (M6), so the fitted state lives on
+    # the copy inside `enc_sch_large`, not on `dd_large` itself - retrieve it from there.
+    achieved_rank_large = size(get_encoder_mat(enc_sch_large[1][1])[1], 1)
     @test 0 < achieved_rank_large < d_large
 end
 

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -962,6 +962,55 @@ end
 
 end
 
+@testset "Decorrelator: small/large-matrix truncation criterion consistency (m28)" begin
+    # m28 regression test. The large-matrix (tsvd) branch must truncate on the same VARIANCE
+    # (trace, Σσᵢ) fraction the small-matrix branch computes exactly, not the sum-of-squares
+    # (Frobenius, Σσᵢ²) fraction it used before. Isolated from the (pre-existing, out-of-scope)
+    # conservative retain_var deflation the tsvd branch applies for estimator uncertainty - that
+    # deflation is itself noisy (depends on a separate Hutchinson estimate of the SPREAD, not
+    # just the mean, of repeated trace draws), which would make an end-to-end achieved-rank
+    # comparison flaky regardless of which criterion is used. So instead verify the underlying
+    # quantity directly: with a `Diagonal` covariance, `tsvd` recovers the exact top-k singular
+    # values, so `sum(Stmp)/tr(C)` (what the fixed code's criterion converges to as its trace
+    # estimate's noise → 0) must equal the small-matrix branch's own `cumsum(svdA.S)/sum(svdA.S)`
+    # at the same rank - and must NOT equal the old `sum(Stmp.^2)/‖C‖²_F` quantity, since that's
+    # provably a different fraction for a non-flat spectrum.
+    d = 200
+    C = Diagonal(exp.(-(1:d) ./ 10)) # exact eigenvalues = sorted diagonal entries
+    true_trace = sum(diag(C))
+    true_frob_sq = sum(diag(C) .^ 2)
+
+    svdA = svd(Matrix(C)) # the small-matrix branch's own (exact) computation
+    small_branch_fracs = cumsum(svdA.S) ./ sum(svdA.S)
+
+    # `tsvd` (a Lanczos-based low-rank method) is only reliable well below full rank; keep
+    # `rk` a small fraction of `d` rather than testing near-full-rank, which is not its
+    # intended regime and not something this fix touches.
+    for rk in (5, 15, 30, 45)
+        _, Stmp, _ = Utilities.tsvd(C, rk)
+        new_frac = sum(Stmp) / true_trace # what the FIXED tsvd branch's criterion targets
+        old_frac = sum(Stmp .^ 2) / true_frob_sq # what the PRE-FIX criterion targeted
+
+        @test isapprox(new_frac, small_branch_fracs[rk]; atol = 1e-8)
+        @test !isapprox(old_frac, small_branch_fracs[rk]; atol = 1e-3)
+    end
+
+    # Smoke test: the tsvd branch (now on the trace criterion) still runs end-to-end without
+    # error or a degenerate (0 or full-rank) result on a genuinely large (> max_svd_size) input.
+    d_large = 3500
+    C_large = Diagonal(exp.(-(1:d_large) ./ 200))
+    io_pairs_large = PairedDataContainer(randn(2, 5), randn(d_large, 5))
+    dd_large = decorrelate_structure_mat(retain_var = 0.9, max_rank = 600)
+    enc_sch_large = create_encoder_schedule((dd_large, "out"))
+    initialize_and_encode_with_schedule!(
+        enc_sch_large,
+        io_pairs_large;
+        output_structure_mats = Dict{Symbol, Utilities.StructureMatrix}(:obs_noise_cov => C_large),
+    )
+    achieved_rank_large = size(get_encoder_mat(dd_large)[1], 1)
+    @test 0 < achieved_rank_large < d_large
+end
+
 @testset "Decorrelator: Large observational covariance" begin
 
     # loop over output dim


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #449 
- Adding `fix-prompt-applier`: On construction of the code-review I create `fix-prompts` Markdowns which are prompts to help fix the bugs found. `fix-prompt-applier` is designed to carry-out the fixes based on these prompts, and update the review.md with status/progress of resolution

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
Fixes to Close #2, focused on encoder-decoder and robustness
- is_initialized(...) method checks if `DataProcessor`s have been initialized. If it is, then it throws a warning that the user is using an old processor (allows for reuse of processors, but tells the user in case of mistake)
- some better rank-stability for CanonicalCorrelation processor
-  decorrelator randomized norm estimator (which does frobenius norm) swapped to trace estimator for consistency with the small matrix setting. Otherwise the criteria for truncating the matrix changes for the small and large dimension setting
- bugfix an off-by-one error in the stencil for likelihood informed processor
- extend the MCMC methods to have nonzero mean in processed space.
- Various robustness catches (e.g. some singular division guards for RF, and encoders, equality bypassing, correctly using passed rngs)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
