### PR TITLE
[audit-2026-07-09] Emulator-specific bugfixes from Audit.

### DIFF
--- a/.claude/skills/fix-prompt-applier/SKILL.md
+++ b/.claude/skills/fix-prompt-applier/SKILL.md
@@ -42,6 +42,22 @@ brief, not a pointer into a conversation you don't have.
 
 ### 2. Apply
 
+- **Confirm the "bug" is actually a bug before changing behavior.** Some
+  findings turn out, on inspection, to be silent-but-correct-by-design rather
+  than a defect — e.g. a finding once claimed a per-output-dimension scalar
+  backend "silently" dropped cross-output noise correlations that its
+  vector-output sibling kept; in fact that backend fits one fully independent
+  model per output dimension, so there's no joint likelihood anywhere in it
+  for a correlation to live in — `Diagonal` is the only structure it can
+  represent, not a lossy shortcut. Check the fix-prompt's own "Do not" section
+  first: the original audit often already made this call (a line like
+  "diagonal-only is the correct capability of ... models" is your signal that
+  the right fix is a warning or docstring, not a behavior change). If the
+  prompt is silent or ambiguous on this, or the code has drifted since the
+  audit, re-derive it yourself from the current source. Getting this wrong
+  runs in both directions: "fixing" correct architecture changes behavior
+  that shouldn't change, while assuming everything is by-design lets a real
+  bug ship as a warned-around silence instead of an actual fix.
 - Find the offending code by the function name and snippet quoted in the
   prompt. Line numbers drift between the audit and the fix session — treat
   them as hints, not anchors; the quoted snippet is what actually locates it.
@@ -59,6 +75,29 @@ brief, not a pointer into a conversation you don't have.
   current code actually does (code drifts between the audit and the fix
   session too), re-read the source and re-derive the math yourself rather than
   guessing. The prompt is the best available hint; the source is ground truth.
+- **Keep fix-prompt IDs out of shipped code.** `C1`, `M7`, `m5`, `h3`, `G4`,
+  and the like are the review's internal shorthand, legible only next to
+  `review.md`'s legend — which the next reader of this source file (a
+  teammate, or the smaller model this skill is written for) won't have open.
+  Never write an ID into a source comment, docstring, or test/testset name,
+  including any test you add to satisfy step 3's Verify section; describe
+  what behavior is being fixed or pinned in plain, self-contained English
+  instead. `review.md` and the fix-prompts themselves are the only place
+  these IDs belong — that's what step 4's Status notes are for.
+- **Comment tersely.** One line pointing at the non-obvious invariant is
+  usually enough; the fuller story — what was wrong, the derivation, prior
+  failed attempts — belongs in review.md's Status note, which has the room
+  for it and is where a reader goes for depth. Reach for more than one line
+  only when the constraint genuinely resists being said in one, and even then
+  keep it short: a source file is where code is read next to, not where a
+  fix's history is told.
+- **New exported methods get a docstring, not a comment above them.** Match
+  the convention neighboring exported functions in the same file already use
+  (check a couple of nearby examples — this package's convention is
+  `$(TYPEDSIGNATURES)` via DocStringExtensions) rather than inventing a new
+  style. Don't also place a comment block above the method: the docstring is
+  the documentation, and a comment duplicating it is redundant on top of
+  fighting the terseness point above.
 
 ### 3. Verify
 
@@ -154,7 +193,10 @@ fix-prompts were flagged as stale (name them, or say none needed it — don't
 pad this line when step 5 found nothing). Keep this compact — one or two
 lines per ID — the point is a scannable record of what's fixed and what now
 guards it, not a re-explanation of the math (that's already in the review and
-the prompt).
+the prompt). If step 2's design-intent check found a finding to be
+correct-by-design, say so plainly rather than reporting it the same way as a
+behavior fix — the reader needs to know a warning/docstring is the whole fix,
+not a partial one.
 
 ## Improving this skill
 

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -132,7 +132,12 @@ builds and initialises the encoder schedule automatically from training data.
 
 $(METHODLIST)
 """
-struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution, NI <: Union{Nothing, NoiseInjector}}
+struct ForwardMapWrapper{
+    FT <: Real,
+    VV <: AbstractVector,
+    PD <: ParameterDistribution,
+    NI <: Union{Nothing, NoiseInjector},
+}
     "function that represents the forward map"
     forward_map::Function
     "a parameter distribution, containing transformations to constrain the forward map inputs"
@@ -314,13 +319,24 @@ is a column of the matrix.
   - `"in"`         → `Dₒ∘G(z)` — inputs already encoded as `z = Eᵢx`.
   - `"out"`        → `G∘Eᵢ(x)` — outputs returned in encoded space.
   - `"in_and_out"` → `G(z)` — inputs encoded, outputs in encoded space (used internally by `sample`).
-- `add_obs_noise_cov` (keyword, default `false`): when `true`, adds the stored
-  observational noise covariance to the returned uncertainty (used internally by `sample`).
+- `add_obs_noise_cov` (keyword, default `false`, canonical definition — see below): when `true`,
+  adds the stored observational noise covariance to the returned uncertainty (used internally by
+  `sample`).
 - Additional keywords are forwarded to the machine-learning tool `predict` method.
 
 Returns `(mean, cov)` where for `N` inputs:
 - 1-D output: `mean` is `[1 × N]`, `cov` is `[1 × N]` variances.
 - p-D output: `mean` is `[p × N]`, `cov` is a length-N iterator of `[p × p]` covariance matrices.
+
+# `add_obs_noise_cov` semantics (canonical; applies identically to every machine learning tool
+and to [`predict(::ForwardMapWrapper, ...)`](@ref))
+
+`false` always returns the pure latent (epistemic, model-only) uncertainty, with no
+observational noise mixed in, regardless of the machine learning tool or its hyperparameters
+(e.g. `GaussianProcess`'s `noise_learn`). `true` adds exactly the stored observational noise
+covariance on top, added centrally here — never by the machine learning tool itself — because the
+output encoder is designed to whiten that covariance to `I` in encoded space, so the addition is
+always `I(encoded_output_dim)` before decoding back to physical units.
 """
 function predict(
     emulator::Emulator{FT},
@@ -361,32 +377,46 @@ function predict(
     else
         encoded_inputs = new_inputs
     end
-    # predict in encoding space
+    # predict in encoding space (always the pure latent/epistemic uncertainty; no MLT backend
+    # is told about `add_obs_noise_cov` — the observational noise is added once, below)
     # returns outputs: [enc_out_dim x n_samples]
     # Scalar-methods uncertainties=variances: [enc_out_dim x n_samples]
     # Vector-methods uncertainties=covariances: [enc_out_dim x enc_out_dim x n_samples)
-    encoded_outputs, encoded_uncertainties = predict(
-        get_machine_learning_tool(emulator),
-        encoded_inputs;
-        add_obs_noise_cov = add_obs_noise_cov,
-        mlt_kwargs...,
-    )
+    encoded_outputs, encoded_uncertainties = predict(get_machine_learning_tool(emulator), encoded_inputs; mlt_kwargs...)
 
     var_or_cov = (ndims(encoded_uncertainties) == 2) ? "var" : "cov"
+
+    # promote to full [enc_out_dim x enc_out_dim x n_samples] covariance slices, whether the MLT
+    # backend is scalar (per-dimension variances) or vector (full covariances)
+    encoded_covariances_mat =
+        zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_uncertainties)[end])
+    if var_or_cov == "var"
+        for (i, col) in enumerate(eachcol(encoded_uncertainties))
+            encoded_covariances_mat[:, :, i] .= Diagonal(col)
+        end
+    else # == "cov"
+        for (i, mat) in enumerate(eachslice(encoded_uncertainties, dims = 3))
+            encoded_covariances_mat[:, :, i] .= mat
+        end
+    end
+
+    # Centralize the observational-noise addition: every output encoder is designed to whiten the
+    # observational noise covariance to `I` in encoded space, so "add the observational noise"
+    # always means "add `I(encoded_output_dim)`" here, uniformly across every MLT backend
+    # (mirrors `predict(::ForwardMapWrapper, ...)`, which has no latent model and does the same).
+    if add_obs_noise_cov
+        for i in 1:size(encoded_covariances_mat, 3)
+            encoded_covariances_mat[:, :, i] .+= I(encoded_output_dim)
+        end
+    end
 
     # return decoded or encoded?
     if out_to_be_decoded
         decoded_outputs = decode_data(emulator, encoded_outputs, "out")
 
-        decoded_covariances = zeros(eltype(encoded_outputs), output_dim, output_dim, size(encoded_uncertainties)[end])
-        if var_or_cov == "var"
-            for (i, col) in enumerate(eachcol(encoded_uncertainties))
-                decoded_covariances[:, :, i] .= Matrix(decode_structure_matrix(emulator, Diagonal(col), "out"))
-            end
-        else # == "cov"
-            for (i, mat) in enumerate(eachslice(encoded_uncertainties, dims = 3))
-                decoded_covariances[:, :, i] .= Matrix(decode_structure_matrix(emulator, mat, "out"))
-            end
+        decoded_covariances = zeros(eltype(encoded_outputs), output_dim, output_dim, size(encoded_covariances_mat, 3))
+        for (i, mat) in enumerate(eachslice(encoded_covariances_mat, dims = 3))
+            decoded_covariances[:, :, i] .= Matrix(decode_structure_matrix(emulator, mat, "out"))
         end
 
         if output_dim > 1
@@ -397,19 +427,6 @@ function predict(
         end
 
     else
-
-        encoded_covariances_mat =
-            zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_uncertainties)[end])
-        if var_or_cov == "var"
-            for (i, col) in enumerate(eachcol(encoded_uncertainties))
-                encoded_covariances_mat[:, :, i] = Diagonal(col)
-            end
-        else # =="cov"
-            for (i, mat) in enumerate(eachslice(encoded_uncertainties, dims = 3))
-                encoded_covariances_mat[:, :, i] = mat
-            end
-        end
-
         if encoded_output_dim > 1
             return encoded_outputs, eachslice(encoded_covariances_mat, dims = 3)
         else
@@ -500,8 +517,9 @@ encoded/decoded as requested.
   - `"in"`         → `G∘Di(z)` — inputs are encoded as `z = Ei(x)`.
   - `"out"`        → `Eo∘G(x)` — outputs returned in encoded space.
   - `"in_and_out"` → `Eo∘G∘Di(z)` — used internally by `sample`.
-- `add_obs_noise_cov` (keyword, default `false`): when `true`, adds observational noise
-  covariance to the returned uncertainty (used internally by `sample`).
+- `add_obs_noise_cov` (keyword, default `false`): see the canonical semantics documented on
+  [`predict(::Emulator, ...)`](@ref) — identical here, adding `I(encoded_output_dim)` before
+  decoding (used internally by `sample`).
 
 Returns `(mean, cov)` with the same shape conventions as [`predict`](@ref).
 """

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -7,6 +7,7 @@ import ..Utilities.encode_data
 import ..Utilities.encode_structure_matrix
 import ..Utilities.decode_data
 import ..Utilities.decode_structure_matrix
+import ..Utilities.get_structure_mat
 
 using DocStringExtensions
 using Statistics
@@ -21,6 +22,7 @@ export build_models!
 export optimize_hyperparameters!
 export predict, encode_data, decode_data, encode_structure_matrix, decode_structure_matrix
 export get_machine_learning_tool, get_io_pairs, get_encoded_io_pairs, get_encoder_schedule
+export get_encoded_obs_noise_cov
 export get_forward_map, get_prior, forward_map_wrapper, get_noise_injector
 """
 $(TYPEDEF)
@@ -54,6 +56,14 @@ end
 function build_models!(mlt, iopairs, input_structure_mats, output_structure_mats, mlt_kwargs...)
     throw_define_mlt(mlt)
 end
+
+# The (already-encoded) observational noise covariance, symmetrized since downstream consumers
+# (e.g. MCMC's `MvNormal`) require it exactly.
+function _resolve_encoded_obs_noise_cov(output_structure_mats)
+    isempty(output_structure_mats) && return nothing
+    M = Matrix(get_structure_mat(output_structure_mats))
+    return 0.5 * (M + M')
+end
 function optimize_hyperparameters!(mlt)
     throw_define_mlt(mlt)
 end
@@ -80,6 +90,10 @@ struct Emulator{FT <: AbstractFloat, VV <: AbstractVector}
     encoded_io_pairs::PairedDataContainer{FT}
     "Store of the pipeline to encode (/decode) the data"
     encoder_schedule::VV
+    "The observational noise covariance in encoded space (`nothing` if none was ever provided);
+    `I(encoded_output_dim)` only coincides with this when the output encoder was built to whiten it
+    (the default schedule when observational noise is provided)."
+    encoded_obs_noise_cov::Union{Nothing, Matrix{FT}}
 end
 
 """
@@ -110,6 +124,14 @@ $(TYPEDSIGNATURES)
 Return the initialised encoder schedule stored in `emulator`.
 """
 get_encoder_schedule(emulator::Emulator) = emulator.encoder_schedule
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the observational noise covariance in encoded space stored in `emulator` (`nothing` if
+none was ever provided at construction).
+"""
+get_encoded_obs_noise_cov(emulator::Emulator) = emulator.encoded_obs_noise_cov
 
 
 ### Forward Map Wrapper
@@ -150,6 +172,10 @@ struct ForwardMapWrapper{
     encoder_schedule::VV
     "For lossy encodings, this determines how to inject noise into the null-space upon decoding"
     noise_injector::NI
+    "The observational noise covariance in encoded space (`nothing` if none was ever provided);
+    `I(encoded_output_dim)` only coincides with this when the output encoder was built to whiten it
+    (the default schedule when observational noise is provided)."
+    encoded_obs_noise_cov::Union{Nothing, Matrix{FT}}
 end
 """
 $(TYPEDSIGNATURES)
@@ -185,6 +211,14 @@ $(TYPEDSIGNATURES)
 Return the initialised encoder schedule stored in `fmw`.
 """
 get_encoder_schedule(fmw::ForwardMapWrapper) = fmw.encoder_schedule
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the observational noise covariance in encoded space stored in `fmw` (`nothing` if none was
+ever provided at construction).
+"""
+get_encoded_obs_noise_cov(fmw::ForwardMapWrapper) = fmw.encoded_obs_noise_cov
 
 """
 $(TYPEDSIGNATURES)
@@ -254,11 +288,15 @@ function Emulator(
 
     # build the machine learning tool in the encoded space
     build_models!(machine_learning_tool, encoded_io_pairs, input_structure_mats, output_structure_mats; mlt_kwargs...)
+
+    encoded_obs_noise_cov = _resolve_encoded_obs_noise_cov(output_structure_mats)
+
     return Emulator{FT, typeof(encoder_schedule)}(
         machine_learning_tool,
         input_output_pairs,
         encoded_io_pairs,
         encoder_schedule,
+        encoded_obs_noise_cov,
     )
 end
 
@@ -377,8 +415,8 @@ function predict(
     else
         encoded_inputs = new_inputs
     end
-    # predict in encoding space (always the pure latent/epistemic uncertainty; no MLT backend
-    # is told about `add_obs_noise_cov` — the observational noise is added once, below)
+    # predict in encoding space (always the pure latent uncertainty; the MLT backend never sees
+    # `add_obs_noise_cov` — the observational noise is added centrally, below)
     # returns outputs: [enc_out_dim x n_samples]
     # Scalar-methods uncertainties=variances: [enc_out_dim x n_samples]
     # Vector-methods uncertainties=covariances: [enc_out_dim x enc_out_dim x n_samples)
@@ -386,8 +424,7 @@ function predict(
 
     var_or_cov = (ndims(encoded_uncertainties) == 2) ? "var" : "cov"
 
-    # promote to full [enc_out_dim x enc_out_dim x n_samples] covariance slices, whether the MLT
-    # backend is scalar (per-dimension variances) or vector (full covariances)
+    # promote to full [enc_out_dim x enc_out_dim x n_samples] covariance slices
     encoded_covariances_mat =
         zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_uncertainties)[end])
     if var_or_cov == "var"
@@ -400,13 +437,12 @@ function predict(
         end
     end
 
-    # Centralize the observational-noise addition: every output encoder is designed to whiten the
-    # observational noise covariance to `I` in encoded space, so "add the observational noise"
-    # always means "add `I(encoded_output_dim)`" here, uniformly across every MLT backend
-    # (mirrors `predict(::ForwardMapWrapper, ...)`, which has no latent model and does the same).
+    # add the observational noise centrally, uniformly across every MLT backend (falls back to
+    # `I` if the emulator was never given any observational noise information at all)
     if add_obs_noise_cov
+        noise_to_add = something(get_encoded_obs_noise_cov(emulator), I(encoded_output_dim))
         for i in 1:size(encoded_covariances_mat, 3)
-            encoded_covariances_mat[:, :, i] .+= I(encoded_output_dim)
+            encoded_covariances_mat[:, :, i] .+= noise_to_add
         end
     end
 
@@ -488,6 +524,7 @@ function forward_map_wrapper(
     # As we apply FMW in decoded space, it may be that we need to add additional noise if the encoder is suitably lossy (determined by >`noise_injector_threshold`). We create a noise injector which puts noise in the null space, retaining correlations from the prior. Precompute it here:
     noise_injector = create_noise_injector(encoder_schedule, prior, noise_injector_threshold, noise_injector_scaling)
 
+    encoded_obs_noise_cov = _resolve_encoded_obs_noise_cov(output_structure_mats)
 
     return ForwardMapWrapper{FT, typeof(encoder_schedule), typeof(prior), typeof(noise_injector)}(
         forward_map,
@@ -496,6 +533,7 @@ function forward_map_wrapper(
         encoded_io_pairs,
         encoder_schedule,
         noise_injector,
+        encoded_obs_noise_cov,
     )
 end
 
@@ -574,8 +612,9 @@ function predict(
     var_or_cov = (output_dim == 1) ? "var" : "cov"
     if out_to_be_decoded
         decoded_cov = if add_obs_noise_cov
-            # uncertainty in encoded space is `I`; decode it back to physical space
-            Matrix(decode_structure_matrix(fmw, I(encoded_output_dim), "out"))
+            # decode the resolved observational noise covariance (falls back to `I`)
+            noise_to_add = something(get_encoded_obs_noise_cov(fmw), I(encoded_output_dim))
+            Matrix(decode_structure_matrix(fmw, noise_to_add, "out"))
         else
             zeros(eltype(decoded_outputs), output_dim, output_dim)
         end
@@ -595,7 +634,9 @@ function predict(
     else # We encode
         encoded_outputs = Matrix(encode_data(fmw, decoded_outputs, "out"))
         encoded_output_dim = size(encoded_outputs, 1)
-        encoded_cov = add_obs_noise_cov ? I(encoded_output_dim) : zeros(encoded_output_dim, encoded_output_dim)
+        encoded_cov =
+            add_obs_noise_cov ? something(get_encoded_obs_noise_cov(fmw), I(encoded_output_dim)) :
+            zeros(encoded_output_dim, encoded_output_dim)
 
         encoded_covariances_mat =
             zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_outputs, 2))

--- a/src/Emulator.jl
+++ b/src/Emulator.jl
@@ -21,7 +21,7 @@ export build_models!
 export optimize_hyperparameters!
 export predict, encode_data, decode_data, encode_structure_matrix, decode_structure_matrix
 export get_machine_learning_tool, get_io_pairs, get_encoded_io_pairs, get_encoder_schedule
-export get_forward_map, get_prior, forward_map_wrapper
+export get_forward_map, get_prior, forward_map_wrapper, get_noise_injector
 """
 $(TYPEDEF)
 
@@ -132,7 +132,7 @@ builds and initialises the encoder schedule automatically from training data.
 
 $(METHODLIST)
 """
-struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution, NI <: NoiseInjector}
+struct ForwardMapWrapper{FT <: Real, VV <: AbstractVector, PD <: ParameterDistribution, NI <: Union{Nothing, NoiseInjector}}
     "function that represents the forward map"
     forward_map::Function
     "a parameter distribution, containing transformations to constrain the forward map inputs"
@@ -555,8 +555,12 @@ function predict(
 
     var_or_cov = (output_dim == 1) ? "var" : "cov"
     if out_to_be_decoded
-        # uncertainty returned is just `I` in encoded space
-        decoded_cov = Matrix(decode_structure_matrix(fmw, I(output_dim), "out"))
+        decoded_cov = if add_obs_noise_cov
+            # uncertainty in encoded space is `I`; decode it back to physical space
+            Matrix(decode_structure_matrix(fmw, I(encoded_output_dim), "out"))
+        else
+            zeros(eltype(decoded_outputs), output_dim, output_dim)
+        end
 
         decoded_covariances = zeros(eltype(decoded_outputs), output_dim, output_dim, size(decoded_outputs, 2))
         for i in 1:size(decoded_covariances, 3)
@@ -573,7 +577,7 @@ function predict(
     else # We encode
         encoded_outputs = Matrix(encode_data(fmw, decoded_outputs, "out"))
         encoded_output_dim = size(encoded_outputs, 1)
-        encoded_cov = I(encoded_output_dim)
+        encoded_cov = add_obs_noise_cov ? I(encoded_output_dim) : zeros(encoded_output_dim, encoded_output_dim)
 
         encoded_covariances_mat =
             zeros(eltype(encoded_outputs), encoded_output_dim, encoded_output_dim, size(encoded_outputs, 2))

--- a/src/MachineLearningTools/GaussianProcess.jl
+++ b/src/MachineLearningTools/GaussianProcess.jl
@@ -302,8 +302,7 @@ predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}, ::YType) wher
 predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}, ::FType) where {FT <: AbstractFloat} =
     _predict(gp, new_inputs, GaussianProcesses.predict_f)
 
-# Fitted variance of a `Noise` kernel component, searched for recursively through `SumKernel`
-# nodes (0.0 if the composite kernel has no such component, e.g. `noise_learn = false`).
+# fitted variance of a `Noise` kernel component, searched recursively through `SumKernel` nodes
 _white_kernel_variance(k::GaussianProcesses.Noise) = k.σ2
 _white_kernel_variance(k::GaussianProcesses.SumKernel) =
     _white_kernel_variance(k.kleft) + _white_kernel_variance(k.kright)
@@ -319,9 +318,8 @@ observational noise covariance when its `add_obs_noise_cov` keyword is `true`. T
 """
 function predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}; mlt_kwargs...) where {FT <: AbstractFloat}
     μ, σ2 = predict(gp, new_inputs, FType())
-    # `predict_f` already includes the fitted white-kernel variance when `noise_learn = true`
-    # (it is part of the composite latent kernel); subtract it so the returned covariance is
-    # purely latent regardless of `noise_learn`.
+    # subtract the fitted white-kernel variance so `noise_learn = true` doesn't leak into the
+    # supposedly latent-only covariance
     white_var = [_white_kernel_variance(model.kernel) for model in gp.models]
     σ2 = max.(σ2 .- white_var, 1e-12)
     return μ, σ2
@@ -413,9 +411,7 @@ function _SKLPy_predict_function(gp_model::Py, new_inputs::AbstractMatrix{FT}) w
     return μ, (σ .* σ)
 end
 
-# Fitted variance of a `WhiteKernel` component anywhere in the (possibly nested) fitted sklearn
-# kernel, found via `get_params(deep=true)`'s flattened `__`-joined parameter names (0.0 if the
-# fitted kernel has no such component).
+# fitted WhiteKernel variance, found via `get_params(deep=true)`'s flattened `__`-joined names
 function _sklearn_white_kernel_variance(fitted_kernel::Py)::Float64
     params = pyconvert(Dict{String, Any}, fitted_kernel.get_params(true))
     for (name, value) in params
@@ -427,9 +423,7 @@ end
 function predict(gp::GaussianProcess{SKLPy}, new_inputs::AbstractMatrix{FT}; mlt_kwargs...) where {FT <: AbstractFloat}
     μ, σ2 = _predict(gp, new_inputs, _SKLPy_predict_function)
 
-    # SKLPy's `.predict(return_std=true)` already includes the fitted WhiteKernel's noise_level
-    # (when `noise_learn = true`) in the returned variance; subtract it so the returned covariance
-    # is purely latent regardless of `noise_learn`.
+    # subtract the fitted WhiteKernel variance, which `.predict(return_std=true)` always includes
     white_var = [_sklearn_white_kernel_variance(model.kernel_) for model in gp.models]
     σ2 = max.(σ2 .- white_var, 1e-12)
 
@@ -538,8 +532,7 @@ function optimize_hyperparameters!(gp::GaussianProcess{AGPJL}, args...; kwargs..
 end
 
 
-# Fitted variance of a `WhiteKernel` component anywhere in the (possibly nested) `KernelFunctions`
-# composite kernel (0.0 if the composite kernel has no such component).
+# fitted WhiteKernel variance, searched recursively through the `KernelFunctions` composite kernel
 _agpjl_white_kernel_variance(k::KernelFunctions.ScaledKernel{<:KernelFunctions.WhiteKernel}) = only(k.σ²)
 _agpjl_white_kernel_variance(k::KernelFunctions.KernelSum) = sum(_agpjl_white_kernel_variance, k.kernels)
 _agpjl_white_kernel_variance(k) = 0.0
@@ -555,8 +548,7 @@ function predict(gp::GaussianProcess{AGPJL}, new_inputs::AM; mlt_kwargs...) wher
         pred_gp = gp.models[i]
         pred = pred_gp(new_inputs; obsdim = 2)
         μ[i, :] = mean(pred)
-        # `var(pred)` already includes the (borrowed, always-present) WhiteKernel variance baked
-        # into the composite prior kernel; subtract it so the returned covariance is purely latent.
+        # subtract the (always-present, borrowed) WhiteKernel variance baked into `var(pred)`
         white_var = _agpjl_white_kernel_variance(pred_gp.prior.kernel)
         σ2[i, :] = max.(var(pred) .- white_var, 1e-12)
     end

--- a/src/MachineLearningTools/GaussianProcess.jl
+++ b/src/MachineLearningTools/GaussianProcess.jl
@@ -159,9 +159,9 @@ end
 # GaussianProcess builds one scalar model per encoded output dimension; warn (once per build)
 # when the output structure matrix (noise covariance) is not diagonal, since only its diagonal
 # is used by the fitting regularization and (via predict(::Emulator,...)) by `add_obs_noise_cov`.
-function _warn_if_offdiagonal_structure_mat(osm::AbstractMatrix, backend::String)
+function _warn_if_offdiagonal_structure_mat(osm::AbstractMatrix, name::String)
     if norm(osm - Diagonal(osm)) > 1e-8 * norm(osm)
-        @warn "GaussianProcess ($backend) fits one scalar model per encoded output dimension: off-diagonal entries of the output structure matrix (noise covariance) are ignored by both the fitting regularization and `add_obs_noise_cov`. Consider a decorrelating output encoder."
+        @warn "$name fits one scalar model per encoded output dimension: off-diagonal entries of the output structure matrix (noise covariance) are ignored by both the fitting regularization and `add_obs_noise_cov`. Consider a decorrelating output encoder."
     end
 end
 
@@ -239,7 +239,7 @@ function build_models!(
         1.0 * ones(N_models)
     else
         osm = Matrix(get_structure_mat(output_structure_mats))
-        _warn_if_offdiagonal_structure_mat(osm, "GPJL")
+        _warn_if_offdiagonal_structure_mat(osm, "GaussianProcess (GPJL)")
         diag(osm)
     end
     regularization_noise = regularization .* gp.alg_reg_noise
@@ -394,7 +394,7 @@ function build_models!(
         1.0 * ones(N_models)
     else
         output_structure_mat = Matrix(get_structure_mat(output_structure_mats))
-        _warn_if_offdiagonal_structure_mat(output_structure_mat, "SKLPy")
+        _warn_if_offdiagonal_structure_mat(output_structure_mat, "GaussianProcess (SKLPy)")
         diag(output_structure_mat)
     end
     regularization_noise_vec = gp.alg_reg_noise .* regularization
@@ -508,7 +508,7 @@ AbstractGP currently does not (yet) learn hyperparameters internally. The follow
         1.0 * ones(N_models)
     else
         output_structure_mat = Matrix(get_structure_mat(output_structure_mats))
-        _warn_if_offdiagonal_structure_mat(output_structure_mat, "AGPJL")
+        _warn_if_offdiagonal_structure_mat(output_structure_mat, "GaussianProcess (AGPJL)")
         diag(output_structure_mat)
     end
     regularization_noise = gp.alg_reg_noise .* regularization

--- a/src/MachineLearningTools/GaussianProcess.jl
+++ b/src/MachineLearningTools/GaussianProcess.jl
@@ -302,19 +302,29 @@ predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}, ::YType) wher
 predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}, ::FType) where {FT <: AbstractFloat} =
     _predict(gp, new_inputs, GaussianProcesses.predict_f)
 
+# Fitted variance of a `Noise` kernel component, searched for recursively through `SumKernel`
+# nodes (0.0 if the composite kernel has no such component, e.g. `noise_learn = false`).
+_white_kernel_variance(k::GaussianProcesses.Noise) = k.σ2
+_white_kernel_variance(k::GaussianProcesses.SumKernel) =
+    _white_kernel_variance(k.kleft) + _white_kernel_variance(k.kright)
+_white_kernel_variance(k) = 0.0
+
 """
 $(TYPEDSIGNATURES)
 
-Predict means and covariances in decorrelated output space using Gaussian process models. The use of stored `FType` and `YType` to control this method is deprecated, the return covariance is now determined by the `predict(` kwarg `add_obs_noise_cov` 
+Predict means and covariances in decorrelated output space using Gaussian process models. Always
+returns the pure latent (noise-free) covariance; `predict(::Emulator, ...)` centrally adds the
+observational noise covariance when its `add_obs_noise_cov` keyword is `true`. The use of stored
+`FType` and `YType` to control this method is deprecated.
 """
-function predict(
-    gp::GaussianProcess{GPJL},
-    new_inputs::AbstractMatrix{FT};
-    add_obs_noise_cov = false,
-    mlt_kwargs...,
-) where {FT <: AbstractFloat}
-    pred_type = add_obs_noise_cov ? YType() : FType()
-    return predict(gp, new_inputs, pred_type)
+function predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}; mlt_kwargs...) where {FT <: AbstractFloat}
+    μ, σ2 = predict(gp, new_inputs, FType())
+    # `predict_f` already includes the fitted white-kernel variance when `noise_learn = true`
+    # (it is part of the composite latent kernel); subtract it so the returned covariance is
+    # purely latent regardless of `noise_learn`.
+    white_var = [_white_kernel_variance(model.kernel) for model in gp.models]
+    σ2 = max.(σ2 .- white_var, 1e-12)
+    return μ, σ2
 end
 
 #now we build the SKLPy implementation
@@ -402,21 +412,26 @@ function _SKLPy_predict_function(gp_model::Py, new_inputs::AbstractMatrix{FT}) w
     σ = pyconvert(Vector{FT}, py_out[1])
     return μ, (σ .* σ)
 end
-function predict(
-    gp::GaussianProcess{SKLPy},
-    new_inputs::AbstractMatrix{FT};
-    add_obs_noise_cov = false,
-    mlt_kwargs...,
-) where {FT <: AbstractFloat}
+
+# Fitted variance of a `WhiteKernel` component anywhere in the (possibly nested) fitted sklearn
+# kernel, found via `get_params(deep=true)`'s flattened `__`-joined parameter names (0.0 if the
+# fitted kernel has no such component).
+function _sklearn_white_kernel_variance(fitted_kernel::Py)::Float64
+    params = pyconvert(Dict{String, Any}, fitted_kernel.get_params(true))
+    for (name, value) in params
+        endswith(name, "noise_level") && return value
+    end
+    return 0.0
+end
+
+function predict(gp::GaussianProcess{SKLPy}, new_inputs::AbstractMatrix{FT}; mlt_kwargs...) where {FT <: AbstractFloat}
     μ, σ2 = _predict(gp, new_inputs, _SKLPy_predict_function)
 
-    # SKLPy does not return the observational noise (even if return_std = true)
-    # we must add contribution depending on whether we learnt the noise or not.
-    if add_obs_noise_cov
-        for i in 1:size(σ2, 2)
-            σ2[:, i] = σ2[:, i] + gp.regularization
-        end
-    end
+    # SKLPy's `.predict(return_std=true)` already includes the fitted WhiteKernel's noise_level
+    # (when `noise_learn = true`) in the returned variance; subtract it so the returned covariance
+    # is purely latent regardless of `noise_learn`.
+    white_var = [_sklearn_white_kernel_variance(model.kernel_) for model in gp.models]
+    σ2 = max.(σ2 .- white_var, 1e-12)
 
     return μ, σ2
 end
@@ -522,12 +537,14 @@ function optimize_hyperparameters!(gp::GaussianProcess{AGPJL}, args...; kwargs..
     @info "AbstractGP already built. Continuing..."
 end
 
-function predict(
-    gp::GaussianProcess{AGPJL},
-    new_inputs::AM;
-    add_obs_noise_cov = false,
-    mlt_kwargs...,
-) where {AM <: AbstractMatrix}
+
+# Fitted variance of a `WhiteKernel` component anywhere in the (possibly nested) `KernelFunctions`
+# composite kernel (0.0 if the composite kernel has no such component).
+_agpjl_white_kernel_variance(k::KernelFunctions.ScaledKernel{<:KernelFunctions.WhiteKernel}) = only(k.σ²)
+_agpjl_white_kernel_variance(k::KernelFunctions.KernelSum) = sum(_agpjl_white_kernel_variance, k.kernels)
+_agpjl_white_kernel_variance(k) = 0.0
+
+function predict(gp::GaussianProcess{AGPJL}, new_inputs::AM; mlt_kwargs...) where {AM <: AbstractMatrix}
 
     N_models = length(gp.models)
     N_samples = size(new_inputs, 2)
@@ -538,12 +555,10 @@ function predict(
         pred_gp = gp.models[i]
         pred = pred_gp(new_inputs; obsdim = 2)
         μ[i, :] = mean(pred)
-        σ2[i, :] = var(pred)
-    end
-    if add_obs_noise_cov
-        for i in 1:size(σ2, 2)
-            σ2[:, i] .= σ2[:, i] + gp.regularization
-        end
+        # `var(pred)` already includes the (borrowed, always-present) WhiteKernel variance baked
+        # into the composite prior kernel; subtract it so the returned covariance is purely latent.
+        white_var = _agpjl_white_kernel_variance(pred_gp.prior.kernel)
+        σ2[i, :] = max.(var(pred) .- white_var, 1e-12)
     end
     return μ, σ2
 end

--- a/src/MachineLearningTools/GaussianProcess.jl
+++ b/src/MachineLearningTools/GaussianProcess.jl
@@ -97,6 +97,18 @@ Construct a `GaussianProcess` for the chosen backend `package`.
 - `noise_learn`: if `true`, learns additive white noise via the kernel. Default `true`.
 - `alg_reg_noise`: small regularisation added by the fitting algorithm when `noise_learn = true`. Default `1e-3`.
 - `prediction_type`: `YType()` (predict observations) or `FType()` (predict latent function). Default `YType()`.
+
+# Backend-dependent WhiteKernel semantics
+
+When `noise_learn = true`, the additive white-noise kernel term behaves differently across
+backends at a query point whose VALUE coincides with a training input: `SKLPy`'s
+`sklearn.gaussian_process.kernels.WhiteKernel` uses object identity (`X is Y`), so a distinct
+query array with the same values as a training point gets zero cross-covariance from the noise
+term; `GPJL` (`GaussianProcesses.jl`'s `Noise`) and `AGPJL` (`KernelFunctions.jl`'s `WhiteKernel`)
+compare by value, so a coincident query point picks up `σ²_noise` from the noise term. With
+identical fitted hyperparameters, the three backends can therefore disagree on the predictive
+variance exactly at (but not near) training inputs. This is inherent to each underlying package's
+kernel implementation and is not something this wrapper corrects.
 """
 function GaussianProcess(
     package::GPPkg;
@@ -144,6 +156,15 @@ function GaussianProcess(
     )
 end
 
+# GaussianProcess builds one scalar model per encoded output dimension; warn (once per build)
+# when the output structure matrix (noise covariance) is not diagonal, since only its diagonal
+# is used by the fitting regularization and (via predict(::Emulator,...)) by `add_obs_noise_cov`.
+function _warn_if_offdiagonal_structure_mat(osm::AbstractMatrix, backend::String)
+    if norm(osm - Diagonal(osm)) > 1e-8 * norm(osm)
+        @warn "GaussianProcess ($backend) fits one scalar model per encoded output dimension: off-diagonal entries of the output structure matrix (noise covariance) are ignored by both the fitting regularization and `add_obs_noise_cov`. Consider a decorrelating output encoder."
+    end
+end
+
 # First we create  the GPJL implementation
 """
 $(TYPEDSIGNATURES)
@@ -185,7 +206,7 @@ function build_models!(
     # Number of models (We are fitting one model per output dimension, as data is decorrelated)
     models = gp.models
     if length(gp.models) > 0 # check to see if gp already contains models
-        @warn "GaussianProcess already built. skipping..."
+        @warn "GaussianProcess already built. skipping... Note: the Emulator constructor calling this always fits a FRESH encoder schedule to the `input_output_pairs` given to it, regardless of this skip. If that data differs from what the existing models were trained on, predictions will pair the old models with mismatched encoders. Construct a fresh GaussianProcess per Emulator unless you are intentionally reusing identical (already-encoded) training data."
         return
     end
     N_models = size(output_values, 1) #size(transformed_data)[1]
@@ -217,7 +238,9 @@ function build_models!(
     regularization = if isempty(output_structure_mats)
         1.0 * ones(N_models)
     else
-        output_structure_mat = diag(Matrix(get_structure_mat(output_structure_mats)))
+        osm = Matrix(get_structure_mat(output_structure_mats))
+        _warn_if_offdiagonal_structure_mat(osm, "GPJL")
+        diag(osm)
     end
     regularization_noise = regularization .* gp.alg_reg_noise
     logstd_regularization_noise = log.(sqrt.(regularization_noise))
@@ -229,7 +252,6 @@ function build_models!(
         kernel_i = deepcopy(kern)
         println("kernel in GaussianProcess:")
         println(kernel_i)
-        data_i = output_values[i, :]
         # GaussianProcesses.GPE() arguments:
         # input_values:    (input_dim × N_samples)
         # GPdata_i:    (N_samples,)
@@ -286,8 +308,8 @@ function _predict(
     M = length(gp.models)
     N_samples = size(new_inputs, 2)
     # Predicts columns of inputs: input_dim × N_samples
-    μ = zeros(M, N_samples)
-    σ2 = zeros(M, N_samples)
+    μ = zeros(FT, M, N_samples)
+    σ2 = zeros(FT, M, N_samples)
     # predict method ::YType will add gp.regularization back in here, ::FType will not
     for i in 1:M
         μ[i, :], σ2[i, :] = predict_method(gp.models[i], new_inputs)
@@ -320,8 +342,8 @@ function predict(gp::GaussianProcess{GPJL}, new_inputs::AbstractMatrix{FT}; mlt_
     μ, σ2 = predict(gp, new_inputs, FType())
     # subtract the fitted white-kernel variance so `noise_learn = true` doesn't leak into the
     # supposedly latent-only covariance
-    white_var = [_white_kernel_variance(model.kernel) for model in gp.models]
-    σ2 = max.(σ2 .- white_var, 1e-12)
+    white_var = FT[_white_kernel_variance(model.kernel) for model in gp.models]
+    σ2 = max.(σ2 .- white_var, FT(1e-12))
     return μ, σ2
 end
 
@@ -339,7 +361,7 @@ function build_models!(
     # Number of models (We are fitting one model per output dimension, as data is decorrelated)
     models = gp.models
     if length(gp.models) > 0 # check to see if gp already contains models
-        @warn "GaussianProcess already built. skipping..."
+        @warn "GaussianProcess already built. skipping... Note: the Emulator constructor calling this always fits a FRESH encoder schedule to the `input_output_pairs` given to it, regardless of this skip. If that data differs from what the existing models were trained on, predictions will pair the old models with mismatched encoders. Construct a fresh GaussianProcess per Emulator unless you are intentionally reusing identical (already-encoded) training data."
         return
     end
 
@@ -372,11 +394,8 @@ function build_models!(
         1.0 * ones(N_models)
     else
         output_structure_mat = Matrix(get_structure_mat(output_structure_mats))
-        if isa(output_structure_mat, UniformScaling)
-            output_structure_mat.λ * ones(N_models)
-        else
-            diag(output_structure_mat)
-        end
+        _warn_if_offdiagonal_structure_mat(output_structure_mat, "SKLPy")
+        diag(output_structure_mat)
     end
     regularization_noise_vec = gp.alg_reg_noise .* regularization
     for i in 1:N_models
@@ -424,8 +443,8 @@ function predict(gp::GaussianProcess{SKLPy}, new_inputs::AbstractMatrix{FT}; mlt
     μ, σ2 = _predict(gp, new_inputs, _SKLPy_predict_function)
 
     # subtract the fitted WhiteKernel variance, which `.predict(return_std=true)` always includes
-    white_var = [_sklearn_white_kernel_variance(model.kernel_) for model in gp.models]
-    σ2 = max.(σ2 .- white_var, 1e-12)
+    white_var = FT[_sklearn_white_kernel_variance(model.kernel_) for model in gp.models]
+    σ2 = max.(σ2 .- white_var, FT(1e-12))
 
     return μ, σ2
 end
@@ -446,7 +465,7 @@ function build_models!(
     # Number of models (We are fitting one model per output dimension, as data is decorrelated)
     models = gp.models
     if length(gp.models) > 0 # check to see if gp already contains models
-        @warn "GaussianProcess already built. skipping..."
+        @warn "GaussianProcess already built. skipping... Note: the Emulator constructor calling this always fits a FRESH encoder schedule to the `input_output_pairs` given to it, regardless of this skip. If that data differs from what the existing models were trained on, predictions will pair the old models with mismatched encoders. Construct a fresh GaussianProcess per Emulator unless you are intentionally reusing identical (already-encoded) training data."
         return
     end
 
@@ -471,8 +490,8 @@ AbstractGP currently does not (yet) learn hyperparameters internally. The follow
    kernel_params = [
        Dict(
            "log_rbf_len" => model_params[1:end-2] # input-dim Vector,
-           "log_std_sqexp" => model_params[end-2] # Float,
-           "log_std_noise" => # Float,
+           "log_std_sqexp" => model_params[end-1] # Float,
+           "log_std_noise" => model_params[end] # Float,
        )
     for model_params in get_params(gp_jl)]
     Note: get_params(gp_jl) returns `output_dim`-vector where each entry is [a, b, c] with:
@@ -489,11 +508,8 @@ AbstractGP currently does not (yet) learn hyperparameters internally. The follow
         1.0 * ones(N_models)
     else
         output_structure_mat = Matrix(get_structure_mat(output_structure_mats))
-        if isa(output_structure_mat, UniformScaling)
-            output_structure_mat.λ * ones(N_models)
-        else
-            diag(output_structure_mat)
-        end
+        _warn_if_offdiagonal_structure_mat(output_structure_mat, "AGPJL")
+        diag(output_structure_mat)
     end
     regularization_noise = gp.alg_reg_noise .* regularization
 

--- a/src/MachineLearningTools/RandomFeature.jl
+++ b/src/MachineLearningTools/RandomFeature.jl
@@ -915,14 +915,11 @@ function estimate_mean_and_coeffnorm_covariance(
 
     # buffers & rng
     moc_tmp = [zeros(output_dim, output_dim, n_test) for i in 1:nthreads]
+    mean_of_covs_tid = [zeros(output_dim, output_dim, n_test) for i in 1:nthreads] # per-thread accumulator; summed into mean_of_covs after the threaded loop to avoid a shared read-modify-write race across threads
     mtmp = [zeros(output_dim, n_test) for i in 1:nthreads]
     buffer = [zeros(n_test, output_dim, n_features) for i in 1:nthreads]
     rng_seed = randperm(rng, 10^5)[1] # dumb way to get a random integer in 1:10^5
-    # one independent MersenneTwister stream per sample (not per thread/chunk), so results are
-    # reproducible regardless of JULIA_NUM_THREADS. A concrete stateful RNG type is required here
-    # (rather than reusing the caller's `rng` type) because the default GLOBAL_RNG/TaskLocalRNG is
-    # a task-local singleton with no independent state to deepcopy or seed per-stream.
-    rng_list = [Random.MersenneTwister(rng_seed + i) for i in 1:n_samples]
+    rng_list = _thread_rng_list(rng, rng_seed, n_samples)
 
     chunked_samples = chunks(1:n_samples, n = nthreads) # could probs do without this package. But gives (tid, idx for tid)
 
@@ -966,9 +963,13 @@ function estimate_mean_and_coeffnorm_covariance(
                 complexity[1, i] += cplxty / repeats
 
                 # update vbles needed for mean
-                @. mean_of_covs += moc_tmp[tid] ./ (repeats * n_samples)
+                @. mean_of_covs_tid[tid] += moc_tmp[tid] ./ (repeats * n_samples)
             end
         end
+    end
+
+    for tid in 1:nthreads # single-threaded reduction avoids the shared read-modify-write race
+        @. mean_of_covs += mean_of_covs_tid[tid]
     end
 
     #put back together after threading
@@ -1041,14 +1042,11 @@ function calculate_ensemble_mean_and_coeffnorm(
 
     # buffers & rng
     moc_tmp = [zeros(output_dim, output_dim, n_test) for i in 1:nthreads]
+    mean_of_covs_tid = [zeros(output_dim, output_dim, n_test) for i in 1:nthreads] # per-thread accumulator; summed into mean_of_covs after the threaded loop to avoid a shared read-modify-write race across threads
     mtmp = [zeros(output_dim, n_test) for i in 1:nthreads]
     buffer = [zeros(n_test, output_dim, n_features) for i in 1:nthreads]
     rng_seed = randperm(rng, 10^5)[1] # dumb way to get a random integer in 1:10^5
-    # one independent MersenneTwister stream per ensemble member (not per thread/chunk), so results
-    # are reproducible regardless of JULIA_NUM_THREADS. A concrete stateful RNG type is required
-    # here (rather than reusing the caller's `rng` type) because the default GLOBAL_RNG/TaskLocalRNG
-    # is a task-local singleton with no independent state to deepcopy or seed per-stream.
-    rng_list = [Random.MersenneTwister(rng_seed + i) for i in 1:N_ens]
+    rng_list = _thread_rng_list(rng, rng_seed, N_ens)
 
     chunked_ensemble = chunks(1:N_ens, n = nthreads) # could probs do without this. But gives (tid, idx for tid)
 
@@ -1084,12 +1082,15 @@ function calculate_ensemble_mean_and_coeffnorm(
                 # v output_dim x output_dim x n_test
                 # c n_features
                 means[:, i, :] += mtmp[tid] ./ repeats
-                @. mean_of_covs += moc_tmp[tid] ./ (repeats * N_ens)
+                @. mean_of_covs_tid[tid] += moc_tmp[tid] ./ (repeats * N_ens)
                 coeffl2norm[1, i] += sqrt(sum(c .^ 2)) / repeats
                 complexity[1, i] += cplxty / repeats
 
             end
         end
+    end
+    for tid in 1:nthreads # single-threaded reduction avoids the shared read-modify-write race
+        @. mean_of_covs += mean_of_covs_tid[tid]
     end
     # put back together after threading
     means = permutedims(means, (3, 2, 1))
@@ -1108,6 +1109,21 @@ function calculate_ensemble_mean_and_coeffnorm(
     end
     return vcat(blockmeans, coeffl2norm, complexity), blockcovmat
 
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Builds `n` independent RNG streams, one per sample/ensemble-member index (not per thread or
+chunk), so that `EnsembleThreading` results are reproducible regardless of `Threads.nthreads()`.
+`copy(rng)` (not `deepcopy`) is used deliberately: for a concrete stateful RNG (e.g.
+`MersenneTwister`, `Xoshiro`) it preserves the caller's RNG type; for the task-local
+default/global RNG singleton, `copy` detaches it into an independent, concrete `Xoshiro` (whereas
+`deepcopy` of a `TaskLocalRNG` returns the *same* singleton object, since there is nothing for a
+generic recursive copy to detach) before it is reseeded.
+"""
+function _thread_rng_list(rng::AbstractRNG, seed::Integer, n::Integer)
+    return [Random.seed!(copy(rng), seed + i) for i in 1:n]
 end
 
 ## Error helpers

--- a/src/MachineLearningTools/RandomFeature.jl
+++ b/src/MachineLearningTools/RandomFeature.jl
@@ -512,7 +512,6 @@ function calculate_mean_cov_and_coeffs(
     )
     fitted_features = RF.Methods.fit(rfm, io_train_cost, decomposition_type = decomp_type)
 
-    #we want to calc 1/var(y-mean)^2 + lambda/m * coeffs^2 in the end
     thread_opt = isa(multithread_type, TullioThreading)
     RF.Methods.predict!(
         rfm,
@@ -525,7 +524,7 @@ function calculate_mean_cov_and_coeffs(
     )
     # sizes (output_dim x n_test), (output_dim x output_dim x n_test) 
 
-    ## TODO - the theory states that the following should be set:
+    # EKI observable (1/sqrt(m))*coeffs; with target 0 this contributes the coefficient penalty (1/m)*||coeffs||^2 of Dunbar, Nelsen, Mutic (arXiv:2407.00584 eq 34/41)
     scaled_coeffs = sqrt(1 / (n_features)) * RF.Methods.get_coeffs(fitted_features)
 
     if decomp_type == "cholesky"

--- a/src/MachineLearningTools/RandomFeature.jl
+++ b/src/MachineLearningTools/RandomFeature.jl
@@ -615,7 +615,7 @@ function nice_cov(sample_mat::AA; δ::FT = 1.0, verbose = false) where {AA <: Ab
     max_exponent = 2 * 5 # must be even
     interp_steps = 100
     # use find the variability in the corr coeff matrix entries
-    std_corrs = (1 .- corr) / sqrt(n_sample_cov)
+    std_corrs = (1 .- corr .^ 2) / sqrt(n_sample_cov)
 
     std_tol = sqrt(sum(std_corrs .^ 2))
     α_min_exceeded = [max_exponent]
@@ -918,13 +918,17 @@ function estimate_mean_and_coeffnorm_covariance(
     mtmp = [zeros(output_dim, n_test) for i in 1:nthreads]
     buffer = [zeros(n_test, output_dim, n_features) for i in 1:nthreads]
     rng_seed = randperm(rng, 10^5)[1] # dumb way to get a random integer in 1:10^5
-    rng_list = [Random.MersenneTwister(rng_seed + i) for i in 1:nthreads]
+    # one independent MersenneTwister stream per sample (not per thread/chunk), so results are
+    # reproducible regardless of JULIA_NUM_THREADS. A concrete stateful RNG type is required here
+    # (rather than reusing the caller's `rng` type) because the default GLOBAL_RNG/TaskLocalRNG is
+    # a task-local singleton with no independent state to deepcopy or seed per-stream.
+    rng_list = [Random.MersenneTwister(rng_seed + i) for i in 1:n_samples]
 
     chunked_samples = chunks(1:n_samples, n = nthreads) # could probs do without this package. But gives (tid, idx for tid)
 
     Threads.@threads for (tid, s_idx) in enumerate(chunked_samples)
-        rngtmp = rng_list[tid]
         for i in s_idx
+            rngtmp = rng_list[i]
 
             for j in 1:repeats
                 @. mtmp[tid] = 0
@@ -1040,13 +1044,17 @@ function calculate_ensemble_mean_and_coeffnorm(
     mtmp = [zeros(output_dim, n_test) for i in 1:nthreads]
     buffer = [zeros(n_test, output_dim, n_features) for i in 1:nthreads]
     rng_seed = randperm(rng, 10^5)[1] # dumb way to get a random integer in 1:10^5
-    rng_list = [Random.MersenneTwister(rng_seed + i) for i in 1:nthreads]
+    # one independent MersenneTwister stream per ensemble member (not per thread/chunk), so results
+    # are reproducible regardless of JULIA_NUM_THREADS. A concrete stateful RNG type is required
+    # here (rather than reusing the caller's `rng` type) because the default GLOBAL_RNG/TaskLocalRNG
+    # is a task-local singleton with no independent state to deepcopy or seed per-stream.
+    rng_list = [Random.MersenneTwister(rng_seed + i) for i in 1:N_ens]
 
     chunked_ensemble = chunks(1:N_ens, n = nthreads) # could probs do without this. But gives (tid, idx for tid)
 
     Threads.@threads for (tid, s_idx) in enumerate(chunked_ensemble)
-        rngtmp = rng_list[tid]
         for i in s_idx
+            rngtmp = rng_list[i]
             l = lmat[:, i]
             for j in collect(1:repeats)
                 @. mtmp[tid] = 0
@@ -1147,6 +1155,25 @@ Got:
 Suggestion:
     Reduce `n_cross_val_sets` to at most $(Int(floor(n_data / n_test))), or increase
     `train_fraction` to produce smaller test sets.
+"""))
+end
+
+@noinline function _throw_cov_sample_multiplier_too_small(cov_sample_multiplier, n_cov_samples_min, n_cov_samples)
+    throw(ArgumentError("""
+`cov_sample_multiplier` is too small: it produces fewer than 2 samples to estimate the
+hyperparameter-optimization covariance, which yields a NaN sample covariance (division by
+n_cov_samples - 1 ≤ 0).
+
+Expected:
+    n_cov_samples = floor(n_cov_samples_min * cov_sample_multiplier) ≥ 2
+
+Got:
+    cov_sample_multiplier = $cov_sample_multiplier
+    n_cov_samples_min     = $n_cov_samples_min
+    n_cov_samples         = $n_cov_samples
+
+Suggestion:
+    Increase `cov_sample_multiplier` to at least $(ceil(2 / n_cov_samples_min, digits = 4)).
 """))
 end
 

--- a/src/MachineLearningTools/ScalarRandomFeature.jl
+++ b/src/MachineLearningTools/ScalarRandomFeature.jl
@@ -626,13 +626,14 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Prediction of emulator mean at new inputs (passed in as columns in a matrix), and a prediction of the total covariance at new inputs equal to (emulator covariance + noise covariance). 
+Prediction of emulator mean and (purely latent) covariance at new inputs (passed in as columns in
+a matrix). `predict(::Emulator, ...)` centrally adds the observational noise covariance when its
+`add_obs_noise_cov` keyword is `true`.
 """
 function predict(
     srfi::ScalarRandomFeatureInterface,
     new_inputs::MM;
     multithread = "ensemble",
-    add_obs_noise_cov = false,
     mlt_kwargs...,
 ) where {MM <: AbstractMatrix}
     M = length(get_rfms(srfi))
@@ -653,16 +654,6 @@ function predict(
             DataContainer(new_inputs),
             tullio_threading = tullio_threading,
         )
-    end
-
-    # add the noise contribution stored within the regularization
-    if add_obs_noise_cov
-        reg = get_regularization(srfi)[1]
-        reg_diag = isa(reg, UniformScaling) ? reg.λ * ones(M) : diag(reg)
-
-        for i in 1:M
-            σ2[i, :] .+= reg_diag[i]
-        end
     end
 
     return μ, σ2

--- a/src/MachineLearningTools/ScalarRandomFeature.jl
+++ b/src/MachineLearningTools/ScalarRandomFeature.jl
@@ -436,10 +436,10 @@ function build_models!(
             prior_out_scale = one(prior_out_scale)
         end
 
-        prior = build_default_prior(input_dim, kernel_structure)
+        prior = optimizer_options["prior"]
 
-        # where prior space has changed we need to rebuild the priors
-        if ndims(prior) > n_hp
+        # where prior space has changed (e.g. truncated encoded dimensions) rebuild the default prior
+        if ndims(prior) != n_hp
 
             # comes from having a truncated output_dimension
             # TODO not really a truncation here, resetting to default
@@ -456,6 +456,8 @@ function build_models!(
         overfit = max(optimizer_options["overfit"], 1e-4)
         n_cov_samples_min = n_test + 2
         n_cov_samples = Int(floor(n_cov_samples_min * max(cov_sample_multiplier, 0.0)))
+        n_cov_samples < 2 &&
+            _throw_cov_sample_multiplier_too_small(cov_sample_multiplier, n_cov_samples_min, n_cov_samples)
 
         println("estimating covariances with " * string(n_cov_samples) * " iterations...")
         observation_vec = []

--- a/src/MachineLearningTools/ScalarRandomFeature.jl
+++ b/src/MachineLearningTools/ScalarRandomFeature.jl
@@ -398,7 +398,9 @@ function build_models!(
     regularization = if isempty(output_structure_mats)
         1.0 * I(n_rfms)
     else
-        output_structure_mat = Diagonal(Matrix(get_structure_mat(output_structure_mats)))
+        osm = Matrix(get_structure_mat(output_structure_mats))
+        _warn_if_offdiagonal_structure_mat(osm, "ScalarRandomFeatureInterface")
+        output_structure_mat = Diagonal(osm)
     end
 
     @info (

--- a/src/MachineLearningTools/ScalarRandomFeature.jl
+++ b/src/MachineLearningTools/ScalarRandomFeature.jl
@@ -487,7 +487,8 @@ function build_models!(
             # blocks:
             Γ = deepcopy(internal_Γ)
             Γ[1:n_test, 1:n_test] += regularization_i(n_test) # approx_σ2
-            Γ[1:n_test, 1:n_test] /= overfit^2 # shrink the data noise artificially
+            Γ[1:n_test, :] ./= overfit # congruence scaling preserves posdef-ness across the data/aux cross-block
+            Γ[:, 1:n_test] ./= overfit
             Γ[(n_test + 1):end, (n_test + 1):end] += I
             # small features this has a larger effect - though doesn't -> I as n-> infty
 

--- a/src/MachineLearningTools/VectorRandomFeature.jl
+++ b/src/MachineLearningTools/VectorRandomFeature.jl
@@ -515,10 +515,12 @@ function build_models!(
 
         # Build the covariance
         Γ = deepcopy(internal_Γ)
-        Γ[1:(n_test * output_dim), 1:(n_test * output_dim)] +=
+        n_gamma_data = n_test * output_dim
+        Γ[1:n_gamma_data, 1:n_gamma_data] +=
             isa(regularization, UniformScaling) ? regularization : kron(I(n_test), regularization) # + approx_σ2
-        Γ[1:(n_test * output_dim), 1:(n_test * output_dim)] /= overfit^2
-        Γ[(n_test * output_dim + 1):end, (n_test * output_dim + 1):end] += I
+        Γ[1:n_gamma_data, :] ./= overfit # congruence scaling preserves posdef-ness across the data/aux cross-block
+        Γ[:, 1:n_gamma_data] ./= overfit
+        Γ[(n_gamma_data + 1):end, (n_gamma_data + 1):end] += I
         data = vcat(reshape(get_outputs(input_output_pairs)[:, test_idx[cv_idx]], :, 1), 0.0, 0.0) #flatten data
 
         if !isposdef(Γ)

--- a/src/MachineLearningTools/VectorRandomFeature.jl
+++ b/src/MachineLearningTools/VectorRandomFeature.jl
@@ -146,7 +146,6 @@ Constructs a `VectorRandomFeatureInterface <: MachineLearningTool` interface for
  - `feature_decomposition = "cholesky"` - choice of how to store decompositions of random features, `cholesky` or `svd` available
  - `optimizer_options = nothing` - Dict of options to pass into EKI optimization of hyperparameters (defaults created in `VectorRandomFeatureInterface` constructor):
       - `"prior"`: the prior for the hyperparameter optimization
-      - "prior_in_scale"/"prior_out_scale": use these to tune the input/output prior scale.
       - `"n_ensemble"`: number of ensemble members
       - `"n_iteration"`: number of eki iterations
       - `"scheduler"`: Learning rate Scheduler (a.k.a. EKP timestepper) Default: DataMisfitController
@@ -399,11 +398,11 @@ function build_models!(
     else
         _throw_unknown_multithread(multithread)
     end
-    prior = build_default_prior(input_dim, output_dim, kernel_structure)
+    prior = optimizer_options["prior"]
     rng = get_rng(vrfi)
 
-    # where prior space has changed we need to rebuild the priors [TODO just build them here in the first place?]
-    if ndims(prior) > n_hp
+    # where prior space has changed (e.g. truncated encoded dimensions) rebuild the default prior
+    if ndims(prior) != n_hp
 
         # comes from having a truncated output_dimension
         # TODO not really a truncation here, resetting to default
@@ -490,6 +489,7 @@ function build_models!(
     cov_correction = optimizer_options["cov_correction"]
     overfit = max(optimizer_options["overfit"], 1e-4)
     n_cov_samples = Int(floor(n_cov_samples_min * max(cov_sample_multiplier, 0.0)))
+    n_cov_samples < 2 && _throw_cov_sample_multiplier_too_small(cov_sample_multiplier, n_cov_samples_min, n_cov_samples)
 
     println("estimating covariances with " * string(n_cov_samples) * " iterations...")
     observation_vec = []
@@ -675,8 +675,7 @@ function predict(vrfi::VectorRandomFeatureInterface, new_inputs::M; mlt_kwargs..
 
     N_samples = size(new_inputs, 2)
     # Predicts columns of inputs: input_dim × N_samples
-    μ, σ2 = RF.Methods.predict(rfm, ff, DataContainer(new_inputs), tullio_threading = "tullio")
-    # μ, σ2 = RF.Methods.predict(rfm, ff, DataContainer(new_inputs), tullio_threading = tullio_threading)
+    μ, σ2 = RF.Methods.predict(rfm, ff, DataContainer(new_inputs), tullio_threading = tullio_threading)
     # sizes (output_dim x n_test), (output_dim x output_dim x n_test)
 
     # force exact symmetry/positive-definiteness, needed by downstream consumers (e.g. MCMC's `MvNormal`)

--- a/src/MachineLearningTools/VectorRandomFeature.jl
+++ b/src/MachineLearningTools/VectorRandomFeature.jl
@@ -656,14 +656,11 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Prediction of data observation (not latent function) at new inputs (passed in as columns in a matrix). That is, we add the observational noise into predictions.
+Prediction of emulator mean and (purely latent) covariance at new inputs (passed in as columns in
+a matrix). `predict(::Emulator, ...)` centrally adds the observational noise covariance when its
+`add_obs_noise_cov` keyword is `true`.
 """
-function predict(
-    vrfi::VectorRandomFeatureInterface,
-    new_inputs::M;
-    add_obs_noise_cov = false,
-    mlt_kwargs...,
-) where {M <: AbstractMatrix}
+function predict(vrfi::VectorRandomFeatureInterface, new_inputs::M; mlt_kwargs...) where {M <: AbstractMatrix}
     input_dim = get_input_dim(vrfi)
     output_dim = get_output_dim(vrfi)
     rfm = get_rfms(vrfi)[1]
@@ -680,18 +677,6 @@ function predict(
     # Predicts columns of inputs: input_dim × N_samples
     μ, σ2 = RF.Methods.predict(rfm, ff, DataContainer(new_inputs), tullio_threading = "tullio")
     # μ, σ2 = RF.Methods.predict(rfm, ff, DataContainer(new_inputs), tullio_threading = tullio_threading)
-    # sizes (output_dim x n_test), (output_dim x output_dim x n_test) 
-    # add the noise contribution from the regularization
-    # note this is because we are predicting the data here, not the latent function.
-    if add_obs_noise_cov
-        lambda = get_regularization(vrfi)[1]
-        for i in 1:N_samples
-            σ2[:, :, i] = 0.5 * (σ2[:, :, i] + permutedims(σ2[:, :, i], (2, 1))) + lambda
-
-            if !isposdef(σ2[:, :, i])
-                σ2[:, :, i] = posdef_correct(σ2[:, :, i])
-            end
-        end
-    end
+    # sizes (output_dim x n_test), (output_dim x output_dim x n_test)
     return μ, σ2
 end

--- a/src/MachineLearningTools/VectorRandomFeature.jl
+++ b/src/MachineLearningTools/VectorRandomFeature.jl
@@ -678,5 +678,14 @@ function predict(vrfi::VectorRandomFeatureInterface, new_inputs::M; mlt_kwargs..
     μ, σ2 = RF.Methods.predict(rfm, ff, DataContainer(new_inputs), tullio_threading = "tullio")
     # μ, σ2 = RF.Methods.predict(rfm, ff, DataContainer(new_inputs), tullio_threading = tullio_threading)
     # sizes (output_dim x n_test), (output_dim x output_dim x n_test)
+
+    # force exact symmetry/positive-definiteness, needed by downstream consumers (e.g. MCMC's `MvNormal`)
+    for i in 1:N_samples
+        σ2[:, :, i] = 0.5 * (σ2[:, :, i] + permutedims(σ2[:, :, i], (2, 1)))
+        if !isposdef(σ2[:, :, i])
+            σ2[:, :, i] = posdef_correct(σ2[:, :, i])
+        end
+    end
+
     return μ, σ2
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -170,7 +170,7 @@ function Base.show(io::IO, ::MIME"text/plain", x::GaussianProcess{P}) where {P}
     else
         n = length(x.models)
         println(io, "GaussianProcess{", nameof(P), "}")
-        println(io, "  n_models    : ", n, " (one per output dimension)")
+        println(io, "  n_models    : ", n, " (one per encoded output dimension)")
         println(io, "  noise_learn : ", x.noise_learn)
         print(io, "  pred_type   : ", nameof(typeof(x.prediction_type)))
     end

--- a/test/Emulator/runtests.jl
+++ b/test/Emulator/runtests.jl
@@ -76,7 +76,7 @@ struct MLTester <: Emulators.MachineLearningTool end
     @test isapprox(norm(decoded_mat - x), 0, atol = tol * p * m)
     @test isapprox(norm(decoded_I - 1.0 * I), 0, atol = tol * d * d)
 
-    # m8: unrecognized `encode` values must throw, not silently behave as `encode = nothing`
+    # unrecognized `encode` values must throw, not silently behave as `encode = nothing`
     @test_throws ArgumentError EM.predict(em, x; encode = "In")
 
     # test obs_noise_cov   (check the warning at the start)
@@ -154,17 +154,17 @@ end
     # Resolution test (Step 7c): passing already-encoded inputs with encode = "in" must not throw
     @test EM.predict(fmw, encode_data(fmw, x_test, "in"); encode = "in") isa Tuple
 
-    # m8: unrecognized `encode` values must throw, not silently behave as `encode = nothing`
+    # unrecognized `encode` values must throw, not silently behave as `encode = nothing`
     @test_throws ArgumentError EM.predict(fmw, x_test; encode = "In")
 
-    # M2: add_obs_noise_cov=false (the default) must return zero covariance for a deterministic map
+    # add_obs_noise_cov=false (the default) must return zero covariance for a deterministic map
     y_pred0, y_cov0 = EM.predict(fmw, x_test)
     @test all(isapprox(norm(y_pred0 - y_test), 0; atol = sqrt(d * m) * tol))
     @test all(isapprox(norm(yc), 0; atol = d * tol) for yc in y_cov0)
     y_pred0_enc, y_cov0_enc = EM.predict(fmw, x_test; encode = "out")
     @test all(isapprox(norm(yc), 0; atol = d * tol) for yc in y_cov0_enc)
 
-    # M3: a truncating output encoder must not crash, and add_obs_noise_cov=true must decode `I` in the *encoded* dimension
+    # a truncating output encoder must not crash, and add_obs_noise_cov=true must decode `I` in the *encoded* dimension
     trunc_schedule = [(decorrelate_sample_cov(), "in"), (decorrelate_sample_cov(retain_var = 0.5), "out")]
     fmw_trunc = forward_map_wrapper(G, prior, io_pairs, encoder_schedule = trunc_schedule)
     @test get_encoded_dim(get_encoder_schedule(fmw_trunc), "out") < d # confirm this encoder actually truncates

--- a/test/Emulator/runtests.jl
+++ b/test/Emulator/runtests.jl
@@ -157,6 +157,34 @@ end
     # m8: unrecognized `encode` values must throw, not silently behave as `encode = nothing`
     @test_throws ArgumentError EM.predict(fmw, x_test; encode = "In")
 
+    # M2: add_obs_noise_cov=false (the default) must return zero covariance for a deterministic map
+    y_pred0, y_cov0 = EM.predict(fmw, x_test)
+    @test all(isapprox(norm(y_pred0 - y_test), 0; atol = sqrt(d * m) * tol))
+    @test all(isapprox(norm(yc), 0; atol = d * tol) for yc in y_cov0)
+    y_pred0_enc, y_cov0_enc = EM.predict(fmw, x_test; encode = "out")
+    @test all(isapprox(norm(yc), 0; atol = d * tol) for yc in y_cov0_enc)
+
+    # M3: a truncating output encoder must not crash, and add_obs_noise_cov=true must decode `I` in the *encoded* dimension
+    trunc_schedule = [(decorrelate_sample_cov(), "in"), (decorrelate_sample_cov(retain_var = 0.5), "out")]
+    fmw_trunc = forward_map_wrapper(G, prior, io_pairs, encoder_schedule = trunc_schedule)
+    @test get_encoded_dim(get_encoder_schedule(fmw_trunc), "out") < d # confirm this encoder actually truncates
+    y_pred_trunc, y_cov_trunc = EM.predict(fmw_trunc, x_test, add_obs_noise_cov = true)
+    D_out, _ = get_decoder_from_schedule(get_encoder_schedule(fmw_trunc), "out")
+    D_out_mat = Matrix(D_out)
+    @test all(isapprox(norm(yc - D_out_mat * D_out_mat'), 0; atol = d * tol) for yc in y_cov_trunc)
+    y_pred_trunc0, y_cov_trunc0 = EM.predict(fmw_trunc, x_test)
+    @test all(isapprox(norm(yc), 0; atol = d * tol) for yc in y_cov_trunc0)
+
+    # ForwardMapWrapper must accept a `nothing` noise_injector: an "out"-only encoder schedule
+    # (no "in" processor at all) makes `create_noise_injector` return `nothing`, which must not
+    # violate the struct's type parameter bound.
+    out_only_schedule = (decorrelate_sample_cov(), "out")
+    fmw_out_only = forward_map_wrapper(G, prior, io_pairs, encoder_schedule = out_only_schedule)
+    @test isnothing(get_noise_injector(fmw_out_only))
+    y_pred_out_only, y_cov_out_only = EM.predict(fmw_out_only, x_test)
+    @test all(isapprox(norm(y_pred_out_only - y_test), 0; atol = sqrt(d * m) * tol))
+    @test all(isapprox(norm(yc), 0; atol = d * tol) for yc in y_cov_out_only)
+
     # with out enc.
     fmw = forward_map_wrapper(G, prior, io_pairs, encoder_kwargs = (; obs_noise_cov = Σ))
     y_pred, y_cov = EM.predict(fmw, x_test, add_obs_noise_cov = true)

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -272,7 +272,7 @@ using CalibrateEmulateSample.Utilities
     @test all(isapprox.(μ4b, μ4_noise_learnt, atol = tol_small))
     @test all(isapprox.(σ4b², σ4²_noise_learnt, atol = tol_small))
 
-    @testset "M9: add_obs_noise_cov centralization (regression for M1, all three GP backends)" begin
+    @testset "add_obs_noise_cov centralization (all three GP backends)" begin
         # `true` minus `false` must equal the decoded noise covariance Σ exactly, for any backend
         σ4²_false_learnt =
             [Matrix(s) for s in Emulators.predict(em4_noise_learnt, new_inputs; add_obs_noise_cov = false)[2]]
@@ -283,7 +283,7 @@ using CalibrateEmulateSample.Utilities
         σ4b²_true = [Matrix(s) for s in σ4b²]
         @test all(isapprox.(σ4b²_true .- σ4b²_false, [Σ for _ in σ4b²_true], atol = 1e-10))
 
-        # M1 regression: with `noise_learn = true`, `false` must be a purely latent variance, much
+        # regression: with `noise_learn = true`, `false` must be a purely latent variance, much
         # smaller than the known noise variance, for GPJL, SKLPy, and AGPJL alike.
         n_dense = 200
         x_dense = reshape(collect(range(0, 2π, length = n_dense)), 1, n_dense)
@@ -329,7 +329,7 @@ using CalibrateEmulateSample.Utilities
         @test only(σ2_true_agpjl) - only(σ2_false_agpjl) ≈ σ_noise^2 atol = 1e-10
     end
 
-    @testset "m7: warn when off-diagonal output noise structure is dropped (GP fits one model per encoded dim)" begin
+    @testset "warn when off-diagonal output noise structure is dropped (GP fits one model per encoded dim)" begin
         # direct unit check of the shared helper, across the exact tolerance boundary the fix
         # needs to get right (a naive exact `isdiag` reintroduces false positives on numerically
         # near-diagonal matrices produced by decorrelation)
@@ -373,7 +373,7 @@ using CalibrateEmulateSample.Utilities
         )
     end
 
-    @testset "h11: predict preserves input eltype (no silent Float64 promotion)" begin
+    @testset "predict preserves input eltype (no silent Float64 promotion)" begin
         # GaussianProcesses.jl (GPJL) cannot mix precisions between a fitted model and a query of a
         # different eltype (it errors deep in its own BLAS calls), so only SKLPy's Python-backed
         # predict — which explicitly `pyconvert`s to the query eltype — is exercised end-to-end here.

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -272,4 +272,65 @@ using CalibrateEmulateSample.Utilities
     @test all(isapprox.(μ4b, μ4_noise_learnt, atol = tol_small))
     @test all(isapprox.(σ4b², σ4²_noise_learnt, atol = tol_small))
 
+    @testset "M9: add_obs_noise_cov centralization (regression for M1, all three GP backends)" begin
+        # `add_obs_noise_cov` is now added centrally in `predict(::Emulator, ...)`, never by the
+        # GP backend, so `true` minus `false` must equal the decoded observational noise
+        # covariance Σ exactly — independent of `noise_learn` and of which GP backend is used.
+        σ4²_false_learnt =
+            [Matrix(s) for s in Emulators.predict(em4_noise_learnt, new_inputs; add_obs_noise_cov = false)[2]]
+        σ4²_true_learnt = [Matrix(s) for s in σ4²_noise_learnt]
+        @test all(isapprox.(σ4²_true_learnt .- σ4²_false_learnt, [Σ for _ in σ4²_true_learnt], atol = 1e-10))
+
+        σ4b²_false = [Matrix(s) for s in Emulators.predict(em_agp_from_gp4, new_inputs; add_obs_noise_cov = false)[2]]
+        σ4b²_true = [Matrix(s) for s in σ4b²]
+        @test all(isapprox.(σ4b²_true .- σ4b²_false, [Σ for _ in σ4b²_true], atol = 1e-10))
+
+        # M1 regression: with `noise_learn = true`, `add_obs_noise_cov = false` must return a
+        # purely latent (epistemic) variance, much smaller than the known noise variance, for
+        # GPJL, SKLPy, and AGPJL alike — previously the learned white-kernel noise leaked into
+        # this path for all three backends.
+        n_dense = 200
+        x_dense = reshape(collect(range(0, 2π, length = n_dense)), 1, n_dense)
+        σ_noise = 0.05
+        y_dense = reshape(sin.(x_dense[1, :]) .+ σ_noise .* randn(n_dense), 1, n_dense)
+        iopairs_dense = PairedDataContainer(x_dense, y_dense, data_are_columns = true)
+        Σ_dense = σ_noise^2 * ones(1, 1)
+        x_interior = reshape([π], 1, 1) # densely sampled interior point: low epistemic uncertainty
+
+        gp_dense = GaussianProcess(GPJL(); noise_learn = true)
+        em_dense_gpjl = Emulator(gp_dense, iopairs_dense; encoder_kwargs = (; obs_noise_cov = Σ_dense))
+        Emulators.optimize_hyperparameters!(em_dense_gpjl)
+        _, σ2_false_gpjl = Emulators.predict(em_dense_gpjl, x_interior; add_obs_noise_cov = false)
+        _, σ2_true_gpjl = Emulators.predict(em_dense_gpjl, x_interior; add_obs_noise_cov = true)
+        @test only(σ2_false_gpjl) < 0.3 * σ_noise^2
+        @test only(σ2_true_gpjl) - only(σ2_false_gpjl) ≈ σ_noise^2 atol = 1e-10
+
+        gp_dense_sklpy = GaussianProcess(SKLPy(); noise_learn = true)
+        em_dense_sklpy = Emulator(gp_dense_sklpy, iopairs_dense; encoder_kwargs = (; obs_noise_cov = Σ_dense))
+        _, σ2_false_sklpy = Emulators.predict(em_dense_sklpy, x_interior; add_obs_noise_cov = false)
+        _, σ2_true_sklpy = Emulators.predict(em_dense_sklpy, x_interior; add_obs_noise_cov = true)
+        @test only(σ2_false_sklpy) < 0.3 * σ_noise^2
+        @test only(σ2_true_sklpy) - only(σ2_false_sklpy) ≈ σ_noise^2 atol = 1e-10
+
+        gp_dense_params = Emulators.get_params(gp_dense)
+        kernel_params_dense = [
+            Dict(
+                "log_rbf_len" => model_params[1:(end - 2)],
+                "log_std_sqexp" => model_params[end - 1],
+                "log_std_noise" => model_params[end],
+            ) for model_params in gp_dense_params
+        ]
+        agp_dense = GaussianProcess(AGPJL(); noise_learn = true)
+        em_dense_agpjl = Emulator(
+            agp_dense,
+            iopairs_dense;
+            encoder_kwargs = (; obs_noise_cov = Σ_dense),
+            kernel_params = kernel_params_dense,
+        )
+        _, σ2_false_agpjl = Emulators.predict(em_dense_agpjl, x_interior; add_obs_noise_cov = false)
+        _, σ2_true_agpjl = Emulators.predict(em_dense_agpjl, x_interior; add_obs_noise_cov = true)
+        @test only(σ2_false_agpjl) < 0.3 * σ_noise^2
+        @test only(σ2_true_agpjl) - only(σ2_false_agpjl) ≈ σ_noise^2 atol = 1e-10
+    end
+
 end

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -273,9 +273,7 @@ using CalibrateEmulateSample.Utilities
     @test all(isapprox.(σ4b², σ4²_noise_learnt, atol = tol_small))
 
     @testset "M9: add_obs_noise_cov centralization (regression for M1, all three GP backends)" begin
-        # `add_obs_noise_cov` is now added centrally in `predict(::Emulator, ...)`, never by the
-        # GP backend, so `true` minus `false` must equal the decoded observational noise
-        # covariance Σ exactly — independent of `noise_learn` and of which GP backend is used.
+        # `true` minus `false` must equal the decoded noise covariance Σ exactly, for any backend
         σ4²_false_learnt =
             [Matrix(s) for s in Emulators.predict(em4_noise_learnt, new_inputs; add_obs_noise_cov = false)[2]]
         σ4²_true_learnt = [Matrix(s) for s in σ4²_noise_learnt]
@@ -285,10 +283,8 @@ using CalibrateEmulateSample.Utilities
         σ4b²_true = [Matrix(s) for s in σ4b²]
         @test all(isapprox.(σ4b²_true .- σ4b²_false, [Σ for _ in σ4b²_true], atol = 1e-10))
 
-        # M1 regression: with `noise_learn = true`, `add_obs_noise_cov = false` must return a
-        # purely latent (epistemic) variance, much smaller than the known noise variance, for
-        # GPJL, SKLPy, and AGPJL alike — previously the learned white-kernel noise leaked into
-        # this path for all three backends.
+        # M1 regression: with `noise_learn = true`, `false` must be a purely latent variance, much
+        # smaller than the known noise variance, for GPJL, SKLPy, and AGPJL alike.
         n_dense = 200
         x_dense = reshape(collect(range(0, 2π, length = n_dense)), 1, n_dense)
         σ_noise = 0.05

--- a/test/GaussianProcess/runtests.jl
+++ b/test/GaussianProcess/runtests.jl
@@ -329,4 +329,121 @@ using CalibrateEmulateSample.Utilities
         @test only(σ2_true_agpjl) - only(σ2_false_agpjl) ≈ σ_noise^2 atol = 1e-10
     end
 
+    @testset "m7: warn when off-diagonal output noise structure is dropped (GP fits one model per encoded dim)" begin
+        # direct unit check of the shared helper, across the exact tolerance boundary the fix
+        # needs to get right (a naive exact `isdiag` reintroduces false positives on numerically
+        # near-diagonal matrices produced by decorrelation)
+        @test_logs (:warn, r"off-diagonal") match_mode = :any Emulators._warn_if_offdiagonal_structure_mat(
+            [1.0 0.5; 0.5 1.0],
+            "GPJL",
+        )
+        @test_logs Emulators._warn_if_offdiagonal_structure_mat([1.0 0.0; 0.0 1.0], "GPJL") # exactly diagonal: silent
+        @test_logs Emulators._warn_if_offdiagonal_structure_mat([1.0 1e-14; 1e-14 1.0], "GPJL") # numerical residual: silent
+
+        # end-to-end: build_models! actually reaches the warning when the user disables
+        # decorrelation and supplies a correlated noise covariance, for all three backends
+        Σ_corr = [1.0 0.5; 0.5 1.0]
+
+        gp_corr = GaussianProcess(GPJL(); kernel = nothing, noise_learn = false)
+        @test_logs (:warn, r"off-diagonal") match_mode = :any Emulator(
+            gp_corr,
+            iopairs2;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = Σ_corr),
+        )
+
+        gp_corr_sklpy =
+            GaussianProcess(SKLPy(); kernel = pykernels.ConstantKernel(1.0) * pykernels.RBF(1.0), noise_learn = false)
+        @test_logs (:warn, r"off-diagonal") match_mode = :any Emulator(
+            gp_corr_sklpy,
+            iopairs2;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = Σ_corr),
+        )
+
+        agp_corr = GaussianProcess(AGPJL(); noise_learn = false)
+        kernel_params_corr =
+            [Dict("log_rbf_len" => [0.0, 0.0], "log_std_sqexp" => 0.0, "log_std_noise" => log(1e-6)) for _ in 1:2]
+        @test_logs (:warn, r"off-diagonal") match_mode = :any Emulator(
+            agp_corr,
+            iopairs2;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = Σ_corr),
+            kernel_params = kernel_params_corr,
+        )
+    end
+
+    @testset "h11: predict preserves input eltype (no silent Float64 promotion)" begin
+        # GaussianProcesses.jl (GPJL) cannot mix precisions between a fitted model and a query of a
+        # different eltype (it errors deep in its own BLAS calls), so only SKLPy's Python-backed
+        # predict — which explicitly `pyconvert`s to the query eltype — is exercised end-to-end here.
+        # This pins the fix to the `max.(σ2 .- white_var, 1e-12)` promotion (an untyped literal and a
+        # Float64 `white_var` silently upcasting an FT=Float32 result) in both GPJL's and SKLPy's
+        # `predict` wrappers.
+        gp_f32 =
+            GaussianProcess(SKLPy(); kernel = pykernels.ConstantKernel(1.0) * pykernels.RBF(1.0), noise_learn = false)
+        em_f32 = Emulator(gp_f32, iopairs; encoder_schedule = [])
+        new_inputs_f32 = Float32.(reshape([0.0, 1.0, 2.0], 1, 3))
+        μ_f32, σ2_f32 = Emulators.predict(gp_f32, new_inputs_f32)
+        @test eltype(μ_f32) == Float32
+        @test eltype(σ2_f32) == Float32
+    end
+
+    @testset "Analytic GP posterior check (test-coverage gap 3): predict matches closed-form k*'(K+σ²I)⁻¹y" begin
+        # Independent reference: hand-coded squared-exponential GP regression posterior,
+        # k(x,x') = σf² exp(-0.5 (x-x')²/ℓ²), on a tiny fixed dataset, checked against all three
+        # backends with FIXED (non-optimized) hyperparameters. This tests the shared data plumbing
+        # (regularization scaling, encode/decode with encoder_schedule=[]) against the textbook GP
+        # regression equations directly, rather than only cross-checking backends against each other.
+        ℓ_a = 1.3
+        σf_a = 0.9
+        σn2_a = 0.02
+        se_kernel(x, xp) = σf_a^2 * exp(-0.5 * (x - xp)^2 / ℓ_a^2)
+
+        x_train_a = [0.1, 0.4, 0.9, 1.5, 2.2]
+        y_train_a = [0.2, -0.3, 0.5, 0.1, -0.4]
+        x_test_a = [0.3, 1.0, 2.0, 3.0]
+
+        K_a = [se_kernel(xi, xj) for xi in x_train_a, xj in x_train_a]
+        Kn_a = K_a + σn2_a * I
+        alpha_a = Kn_a \ y_train_a
+        Kstar_a = [se_kernel(xi, xj) for xi in x_test_a, xj in x_train_a] # n_test x n_train
+        mean_analytic = Kstar_a * alpha_a
+        var_analytic = [σf_a^2 - Kstar_a[i, :]' * (Kn_a \ Kstar_a[i, :]) for i in 1:length(x_test_a)]
+
+        iopairs_a = PairedDataContainer(reshape(x_train_a, 1, :), reshape(y_train_a, 1, :), data_are_columns = true)
+        Σ_a = σn2_a * ones(1, 1)
+        new_inputs_a = reshape(x_test_a, 1, :)
+
+        # GPJL
+        gp_a_gpjl = GaussianProcess(GPJL(); kernel = SE(log(ℓ_a), log(σf_a)), noise_learn = false)
+        em_a_gpjl = Emulator(gp_a_gpjl, iopairs_a; encoder_schedule = [], encoder_kwargs = (; obs_noise_cov = Σ_a))
+        μ_a_gpjl, σ2_a_gpjl = Emulators.predict(em_a_gpjl, new_inputs_a; add_obs_noise_cov = false)
+        @test vec(μ_a_gpjl) ≈ mean_analytic atol = 1e-8
+        @test vec(σ2_a_gpjl) ≈ var_analytic atol = 1e-8
+
+        # SKLPy (bounds fixed so `.fit()` does not re-optimize the given hyperparameters)
+        var_kern_a = pykernels.ConstantKernel(constant_value = σf_a^2, constant_value_bounds = "fixed")
+        rbf_kern_a = pykernels.RBF(length_scale = ℓ_a, length_scale_bounds = "fixed")
+        gp_a_sklpy = GaussianProcess(SKLPy(); kernel = var_kern_a * rbf_kern_a, noise_learn = false)
+        em_a_sklpy = Emulator(gp_a_sklpy, iopairs_a; encoder_schedule = [], encoder_kwargs = (; obs_noise_cov = Σ_a))
+        μ_a_sklpy, σ2_a_sklpy = Emulators.predict(em_a_sklpy, new_inputs_a; add_obs_noise_cov = false)
+        @test vec(μ_a_sklpy) ≈ mean_analytic atol = 1e-8
+        @test vec(σ2_a_sklpy) ≈ var_analytic atol = 1e-8
+
+        # AGPJL (kernel_params supplied directly; no internal optimization ever occurs)
+        agp_a = GaussianProcess(AGPJL(); noise_learn = false)
+        kernel_params_a = Dict("log_rbf_len" => [log(ℓ_a)], "log_std_sqexp" => log(σf_a), "log_std_noise" => log(1e-6))
+        em_a_agpjl = Emulator(
+            agp_a,
+            iopairs_a;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = Σ_a),
+            kernel_params = kernel_params_a,
+        )
+        μ_a_agpjl, σ2_a_agpjl = Emulators.predict(em_a_agpjl, new_inputs_a; add_obs_noise_cov = false)
+        @test vec(μ_a_agpjl) ≈ mean_analytic atol = 1e-8
+        @test vec(σ2_a_agpjl) ≈ var_analytic atol = 1e-8
+    end
+
 end

--- a/test/MarkovChainMonteCarlo/runtests.jl
+++ b/test/MarkovChainMonteCarlo/runtests.jl
@@ -646,7 +646,7 @@ end
 
         noise_injector = create_noise_injector(lossless_sch, prior_1d, 0.0, 0.5)
 
-        # m20: `decode_and_add_noise` must be reproducible under a shared rng, and
+        # regression: `decode_and_add_noise` must be reproducible under a shared rng, and
         # independent of the global RNG state
         rng1 = MersenneTwister(24)
         rng2 = MersenneTwister(24)
@@ -856,8 +856,8 @@ end
             # (1-ρ²)C gives 5·RMS ≈ 0.067 (both at stepsize=0.5, n_draws=10_000).
             #
             # pCN is constructed with a genuinely NON-zero, fixed (not rng-drawn, so the gap below
-            # is guaranteed rather than incidental) prior mean `m` here (regression test for the C1
-            # secondary defect: pCN previously always contracted toward 0 regardless of the encoded
+            # is guaranteed rather than incidental) prior mean `m` here (regression test for pCN's
+            # recentering defect: pCN previously always contracted toward 0 regardless of the encoded
             # prior's actual mean). If `transition_kernel` silently ignored `m` and contracted
             # toward 0 instead, this test would fail: the analytic reference below is
             # `m + ρ(a - m)`, which only coincides with `ρ*a` when `m` happens to be 0.
@@ -984,8 +984,8 @@ end
             @test isapprox(var(draws), post_var; rtol = 0.05)
         end
 
-        @testset "pCN: recovers the exact 1D conjugate-Gaussian posterior for a NON-zero-mean prior (regression for C1 secondary defect)" begin
-            # Full-sampler-level regression test for C1's secondary defect: pCN previously
+        @testset "pCN: recovers the exact 1D conjugate-Gaussian posterior for a NON-zero-mean prior (regression for the pCN recentering defect)" begin
+            # Full-sampler-level regression test for pCN's recentering defect: pCN previously
             # contracted its proposal toward 0 regardless of the prior's actual mean, which is
             # only correct in the special case of a zero-mean prior. Here the prior mean m=2 is
             # deliberately non-zero, isolating exactly this defect (everything else matches the

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -145,6 +145,25 @@ rng = Random.MersenneTwister(seed)
         good_cov = nice_cov(samples, verbose = true)
         @test (cond(good_cov) < 100) && ((good_cov[1] < 5.0) && (good_cov[1] > 0.2))
 
+        # m1 regression: the noise level of the sample correlation coefficient must be estimated
+        # as (1-corr^2)/sqrt(N) (standard asymptotics for the sample correlation coefficient),
+        # not the sign-asymmetric (1-corr)/sqrt(N) previously coded. Monte-Carlo the empirical
+        # std of the sample correlation at a fixed true correlation and check it matches the
+        # corrected formula much more closely than the old, wrong one.
+        rng_nice = Random.MersenneTwister(555)
+        rho_true = 0.8
+        n_mc = 20_000
+        n_per_sample = 50
+        corr_draws = [
+            cor(rand(rng_nice, MvNormal([0.0, 0.0], [1.0 rho_true; rho_true 1.0]), n_per_sample), dims = 2)[1, 2]
+            for _ in 1:n_mc
+        ]
+        empirical_std = std(corr_draws)
+        old_formula_std = (1 - rho_true) / sqrt(n_per_sample)
+        new_formula_std = (1 - rho_true^2) / sqrt(n_per_sample)
+        @test abs(empirical_std - new_formula_std) < abs(empirical_std - old_formula_std)
+        @test isapprox(empirical_std, new_formula_std, rtol = 0.1)
+
     end
 
     @testset "ScalarRandomFeatureInterface" begin
@@ -206,6 +225,86 @@ rng = Random.MersenneTwister(seed)
             end
         end
 
+    end
+
+    @testset "M5: custom hyperparameter prior takes effect (regression)" begin
+        # previously `build_models!` always silently rebuilt `build_default_prior(...)`,
+        # ignoring any user-supplied `optimizer_options["prior"]` (the rebuild-guard branch
+        # `ndims(prior) > n_hp` could never fire since both were computed from the same
+        # input_dim/kernel_structure). Assert that a strongly-shifted custom prior actually
+        # changes the fit relative to the default prior.
+        input_dim = 1
+        n_train = 30
+        x = reshape(2.0 * π * rand(Random.MersenneTwister(seed), n_train), 1, n_train)
+        y = reshape(sin.(x) + 0.02 * randn(Random.MersenneTwister(seed + 1), n_train)', 1, n_train)
+        iopairs = PairedDataContainer(x, y, data_are_columns = true)
+        new_inputs = reshape(2.0 * π * rand(Random.MersenneTwister(seed + 2), 20), 1, 20)
+
+        kernel_structure = SeparableKernel(CholeskyFactor(1e-8), OneDimFactor())
+        n_hp = calculate_n_hyperparameters(input_dim, kernel_structure)
+        default_prior = build_default_prior(input_dim, kernel_structure)
+        shifted_prior = constrained_gaussian("shifted_cholesky", 20.0, 1e-6, -Inf, Inf, repeats = n_hp)
+
+        srfi_default = ScalarRandomFeatureInterface(
+            100,
+            input_dim,
+            kernel_structure = kernel_structure,
+            rng = Random.MersenneTwister(seed),
+            optimizer_options = Dict("n_cross_val_sets" => 0, "prior" => default_prior),
+        )
+        em_default = Emulator(srfi_default, iopairs)
+        μ_default, _ = Emulators.predict(em_default, new_inputs)
+
+        srfi_shifted = ScalarRandomFeatureInterface(
+            100,
+            input_dim,
+            kernel_structure = kernel_structure,
+            rng = Random.MersenneTwister(seed),
+            optimizer_options = Dict("n_cross_val_sets" => 0, "prior" => shifted_prior),
+        )
+        em_shifted = Emulator(srfi_shifted, iopairs)
+        μ_shifted, _ = Emulators.predict(em_shifted, new_inputs)
+
+        @test norm(μ_default - μ_shifted) > 1e-3
+
+        # a prior with a stale hyperparameter count (from a since-changed input/kernel_structure)
+        # must still fall back to the default rather than propagating a shape mismatch
+        stale_prior = constrained_gaussian("stale", 0.0, 0.1, -Inf, Inf, repeats = n_hp + 2)
+        srfi_stale = ScalarRandomFeatureInterface(
+            100,
+            input_dim,
+            kernel_structure = kernel_structure,
+            rng = Random.MersenneTwister(seed),
+            optimizer_options = Dict("n_cross_val_sets" => 0, "prior" => stale_prior),
+        )
+        @test_logs (:info,) match_mode = :any Emulator(srfi_stale, iopairs)
+    end
+
+    @testset "h5: cov_sample_multiplier too small throws instead of yielding NaN covariance" begin
+        input_dim = 1
+        n_train = 20
+        x = reshape(2.0 * π * rand(Random.MersenneTwister(seed), n_train), 1, n_train)
+        y = reshape(sin.(x) + 0.02 * randn(Random.MersenneTwister(seed + 1), n_train)', 1, n_train)
+        iopairs = PairedDataContainer(x, y, data_are_columns = true)
+
+        srfi_bad = ScalarRandomFeatureInterface(
+            100,
+            input_dim,
+            rng = rng,
+            optimizer_options = Dict("cov_sample_multiplier" => 0.0),
+        )
+        thrown = @test_throws ArgumentError Emulator(srfi_bad, iopairs)
+        @test contains(thrown.value.msg, "cov_sample_multiplier")
+
+        vrfi_bad = VectorRandomFeatureInterface(
+            100,
+            input_dim,
+            1,
+            rng = rng,
+            optimizer_options = Dict("cov_sample_multiplier" => 0.0),
+        )
+        thrown = @test_throws ArgumentError Emulator(vrfi_bad, iopairs)
+        @test contains(thrown.value.msg, "cov_sample_multiplier")
     end
 
     @testset "VectorRandomFeatureInterface" begin

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -145,7 +145,7 @@ rng = Random.MersenneTwister(seed)
         good_cov = nice_cov(samples, verbose = true)
         @test (cond(good_cov) < 100) && ((good_cov[1] < 5.0) && (good_cov[1] > 0.2))
 
-        # m1 regression: the noise level of the sample correlation coefficient must be estimated
+        # regression: the noise level of the sample correlation coefficient must be estimated
         # as (1-corr^2)/sqrt(N) (standard asymptotics for the sample correlation coefficient),
         # not the sign-asymmetric (1-corr)/sqrt(N) previously coded. Monte-Carlo the empirical
         # std of the sample correlation at a fixed true correlation and check it matches the
@@ -163,6 +163,47 @@ rng = Random.MersenneTwister(seed)
         new_formula_std = (1 - rho_true^2) / sqrt(n_per_sample)
         @test abs(empirical_std - new_formula_std) < abs(empirical_std - old_formula_std)
         @test isapprox(empirical_std, new_formula_std, rtol = 0.1)
+
+        # regression: `_thread_rng_list` builds one independent RNG stream per sample index
+        # (not per thread/chunk), so it must be a pure function of (rng, seed, n) -- its output
+        # for the first k entries cannot change as n grows, i.e. it does NOT depend on however
+        # Threads.nthreads() happens to chunk 1:n at call time.
+        base_seed = 4242
+        list_n3 = Emulators._thread_rng_list(Random.MersenneTwister(1), base_seed, 3)
+        list_n7 = Emulators._thread_rng_list(Random.MersenneTwister(1), base_seed, 7)
+        @test rand.(list_n3) == rand.(list_n7)[1:3]
+
+        # determinism: identical (rng type+state, seed, n) => bit-identical streams
+        @test rand.(Emulators._thread_rng_list(Random.MersenneTwister(11), 100, 5)) ==
+              rand.(Emulators._thread_rng_list(Random.MersenneTwister(11), 100, 5))
+
+        # regression: the caller's concrete RNG *type* is now respected (previously the code
+        # always built `Random.MersenneTwister(seed+i)` regardless of the caller's rng, so this
+        # branch could never be exercised); the incoming rng's pre-existing *state* does not
+        # matter (each stream is explicitly `Random.seed!`-reset), only its type and the `seed`
+        # argument, so a different `seed` argument must give different per-sample streams.
+        list_seed1 = Emulators._thread_rng_list(Random.MersenneTwister(1234), 0, 4)
+        list_seed2 = Emulators._thread_rng_list(Random.MersenneTwister(5678), 0, 4)
+        @test all(isa.(list_seed1, Random.MersenneTwister))
+        @test rand.(list_seed1) == rand.(list_seed2) # same type, same seed arg => same streams regardless of the input instance's own state
+        list_diff_seed = Emulators._thread_rng_list(Random.MersenneTwister(1234), 999, 4)
+        @test rand.(list_seed1) != rand.(list_diff_seed)
+        list_xoshiro = Emulators._thread_rng_list(Random.Xoshiro(1), 0, 3)
+        @test all(isa.(list_xoshiro, Random.Xoshiro))
+
+        # the non-copyable default/global RNG singleton is the case that made a prior `deepcopy`-
+        # based attempt at this fix unsafe (`deepcopy(Random.default_rng()) === Random.default_rng()`,
+        # i.e. not an independent copy). `copy` must detach it into an independent, non-degenerate
+        # stream without perturbing the global RNG's own state.
+        @test deepcopy(Random.default_rng()) === Random.default_rng()
+        Random.seed!(Random.default_rng(), 42)
+        pre_global_draw = rand()
+        Random.seed!(Random.default_rng(), 42)
+        default_streams = Emulators._thread_rng_list(Random.default_rng(), 999, 3)
+        rand(default_streams[1], 1000) # heavily consume one derived stream
+        post_global_draw = rand()
+        @test pre_global_draw == post_global_draw # global stream untouched by consuming a derived one
+        @test length(unique(rand.(default_streams))) == 3 # 3 independent, non-degenerate streams
 
     end
 
@@ -227,7 +268,7 @@ rng = Random.MersenneTwister(seed)
 
     end
 
-    @testset "M5: custom hyperparameter prior takes effect (regression)" begin
+    @testset "custom hyperparameter prior takes effect (regression)" begin
         # previously `build_models!` always silently rebuilt `build_default_prior(...)`,
         # ignoring any user-supplied `optimizer_options["prior"]` (the rebuild-guard branch
         # `ndims(prior) > n_hp` could never fire since both were computed from the same
@@ -280,7 +321,7 @@ rng = Random.MersenneTwister(seed)
         @test_logs (:info,) match_mode = :any Emulator(srfi_stale, iopairs)
     end
 
-    @testset "h5: cov_sample_multiplier too small throws instead of yielding NaN covariance" begin
+    @testset "cov_sample_multiplier too small throws instead of yielding NaN covariance" begin
         input_dim = 1
         n_train = 20
         x = reshape(2.0 * π * rand(Random.MersenneTwister(seed), n_train), 1, n_train)
@@ -305,6 +346,54 @@ rng = Random.MersenneTwister(seed)
         )
         thrown = @test_throws ArgumentError Emulator(vrfi_bad, iopairs)
         @test contains(thrown.value.msg, "cov_sample_multiplier")
+    end
+
+    @testset "EnsembleThreading mean_of_covs reduction is race-free (regression)" begin
+        # `estimate_mean_and_coeffnorm_covariance`/`calculate_ensemble_mean_and_coeffnorm`
+        # (EnsembleThreading methods) used to accumulate into a single shared `mean_of_covs`
+        # array via `@. mean_of_covs += ...` inside `Threads.@threads` -- a data race across
+        # threads. This test environment runs with Threads.nthreads() = $(Threads.nthreads()),
+        # so if the race were still present, re-running the identical seeded fit under real
+        # thread contention could occasionally drop concurrent increments and silently return a
+        # different answer from run to run. After the fix (each thread accumulates into its own
+        # slot; the slots are summed sequentially after the parallel region), repeated runs with
+        # the same seed must be bit-for-bit identical.
+        input_dim = 1
+        n_train = 40
+        x = reshape(2.0 * π * rand(Random.MersenneTwister(seed), n_train), 1, n_train)
+        y = reshape(sin.(x) + 0.02 * randn(Random.MersenneTwister(seed + 1), n_train)', 1, n_train)
+        iopairs = PairedDataContainer(x, y, data_are_columns = true)
+        new_inputs = reshape(2.0 * π * rand(Random.MersenneTwister(seed + 2), 10), 1, 10)
+
+        kernel_structure = SeparableKernel(CholeskyFactor(1e-8), OneDimFactor())
+        opts = Dict(
+            "n_ensemble" => 60,
+            "n_iteration" => 3,
+            "n_features_opt" => 60,
+            "cov_sample_multiplier" => 5.0,
+            "multithread" => "ensemble",
+            "n_cross_val_sets" => 1,
+            "verbose" => false,
+        )
+
+        function build_and_predict()
+            srfi = ScalarRandomFeatureInterface(
+                60,
+                input_dim,
+                kernel_structure = kernel_structure,
+                rng = Random.MersenneTwister(20260811),
+                optimizer_options = deepcopy(opts),
+            )
+            em = Emulator(srfi, iopairs)
+            return Emulators.predict(em, new_inputs)
+        end
+
+        μ1, σ1 = build_and_predict()
+        for _ in 1:4
+            μi, σi = build_and_predict()
+            @test μ1 == μi
+            @test σ1 == σi
+        end
     end
 
     @testset "VectorRandomFeatureInterface" begin
@@ -654,7 +743,7 @@ rng = Random.MersenneTwister(seed)
 
     end
 
-    # G3 regression test: a constant input (or output) dimension must not produce Inf/NaN
+    # regression test: a constant input (or output) dimension must not produce Inf/NaN
     # scales (and hence NaN/PosDefException deep in the hyperparameter prior); build_models!
     # should warn and fall back to scale = 1 for the degenerate dimension(s) instead.
     @testset "Scalar/VectorRandomFeatureInterface: degenerate (constant) input dimension" begin
@@ -702,7 +791,7 @@ rng = Random.MersenneTwister(seed)
         @test all(isfinite, σ2_v_deg)
     end
 
-    # G3 regression test, output side: a constant output dimension must not produce Inf/NaN
+    # regression test, output side: a constant output dimension must not produce Inf/NaN
     # scales (and hence NaN/PosDefException deep in the hyperparameter prior); build_models!
     # should warn and fall back to scale = 1 for the degenerate output dimension(s) instead.
     @testset "Scalar/VectorRandomFeatureInterface: degenerate (constant) output dimension" begin

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -396,6 +396,47 @@ rng = Random.MersenneTwister(seed)
         end
     end
 
+    @testset "warn when off-diagonal output noise structure is dropped (ScalarRandomFeatureInterface fits one model per output dim)" begin
+        # end-to-end: build_models! reaches the shared helper (the same one GaussianProcess uses,
+        # Emulators._warn_if_offdiagonal_structure_mat) when the user disables decorrelation and
+        # supplies a correlated output noise covariance. ScalarRandomFeatureInterface fits one fully
+        # independent scalar model per output dimension, so off-diagonal noise correlations have
+        # nowhere to enter the regularization -- Diagonal is the only structure it can represent,
+        # not a lossy shortcut, but the user should be warned rather than left silently unaware.
+        input_dim = 1
+        output_dim = 2
+        n_train = 30
+        x = reshape(2.0 * π * rand(Random.MersenneTwister(seed), n_train), 1, n_train)
+        y = vcat(sin.(x), cos.(x)) .+ 0.01 .* randn(Random.MersenneTwister(seed + 1), output_dim, n_train)
+        iopairs_corr = PairedDataContainer(x, y, data_are_columns = true)
+        Σ_corr = [1.0 0.5; 0.5 1.0]
+
+        srfi_corr = ScalarRandomFeatureInterface(
+            50,
+            input_dim,
+            rng = Random.MersenneTwister(seed),
+            optimizer_options = Dict("n_cross_val_sets" => 0),
+        )
+        @test_logs (:warn, r"off-diagonal") match_mode = :any Emulator(
+            srfi_corr,
+            iopairs_corr;
+            encoder_schedule = [],
+            encoder_kwargs = (; obs_noise_cov = Σ_corr),
+        )
+
+        # a diagonal output noise covariance must stay silent (no spurious warning)
+        srfi_diag = ScalarRandomFeatureInterface(
+            50,
+            input_dim,
+            rng = Random.MersenneTwister(seed),
+            optimizer_options = Dict("n_cross_val_sets" => 0),
+        )
+        logs, _ = Test.collect_test_logs() do
+            Emulator(srfi_diag, iopairs_corr; encoder_schedule = [], encoder_kwargs = (; obs_noise_cov = 1.0 * I))
+        end
+        @test !any(occursin("off-diagonal", l.message) for l in logs)
+    end
+
     @testset "VectorRandomFeatureInterface" begin
 
         rng = Random.MersenneTwister(seed)

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -408,9 +408,7 @@ rng = Random.MersenneTwister(seed)
         @test isapprox.(norm(μv - new_outputs), 0, atol = tol_μ)
         @test all(isapprox.(vec(σv²), 0.05^2 * ones(ntest), atol = 1e-2))
 
-        # M9: `add_obs_noise_cov` is added centrally in `predict(::Emulator, ...)`, never by the
-        # MLT backend, so `true` minus `false` must equal the decoded observational noise
-        # covariance (here `0.05^2`) exactly, for both scalar and vector RF interfaces.
+        # `true` minus `false` must equal the decoded noise covariance (here `0.05^2`) exactly
         _, σs²_false = Emulators.predict(em_srfi, new_inputs; add_obs_noise_cov = false)
         @test all(isapprox.(vec(σs²) .- vec(σs²_false), 0.05^2, atol = 1e-10))
 

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -207,6 +207,31 @@ rng = Random.MersenneTwister(seed)
 
     end
 
+    @testset "overfit rescaling of the EKI covariance stays positive-definite" begin
+        # build_models! assembles Γ from a sample covariance internal_Γ (data block correlated
+        # with the trailing coefficient-norm/complexity rows) plus an additive regularization
+        # block, then rescales only the data block by `overfit`. Scaling data rows AND columns
+        # (a congruence) must keep Γ positive-definite regardless of overfit; scaling only the
+        # data-data block (the old code) does not once cross-block correlation is present.
+        rng_pd = Random.MersenneTwister(1357)
+        n_test = 10
+        dim = n_test + 2
+        A = randn(rng_pd, dim, 3 * dim)
+        A[end - 1, :] .= 0.6 .* vec(mean(A[1:n_test, :], dims = 1)) .+ 0.4 .* randn(rng_pd, 3 * dim)
+        A[end, :] .= 0.5 .* A[end - 1, :] .+ 0.5 .* randn(rng_pd, 3 * dim)
+        internal_Γ = cov(A, dims = 2)
+        regularization_block = 0.1 * I(n_test)
+
+        for overfit in (0.5, 1.0, 5.0)
+            Γ = deepcopy(internal_Γ)
+            Γ[1:n_test, 1:n_test] += regularization_block
+            Γ[1:n_test, :] ./= overfit
+            Γ[:, 1:n_test] ./= overfit
+            Γ[(n_test + 1):end, (n_test + 1):end] += I
+            @test isposdef(Γ)
+        end
+    end
+
     @testset "ScalarRandomFeatureInterface" begin
 
         input_dim = 2

--- a/test/RandomFeature/runtests.jl
+++ b/test/RandomFeature/runtests.jl
@@ -408,6 +408,15 @@ rng = Random.MersenneTwister(seed)
         @test isapprox.(norm(μv - new_outputs), 0, atol = tol_μ)
         @test all(isapprox.(vec(σv²), 0.05^2 * ones(ntest), atol = 1e-2))
 
+        # M9: `add_obs_noise_cov` is added centrally in `predict(::Emulator, ...)`, never by the
+        # MLT backend, so `true` minus `false` must equal the decoded observational noise
+        # covariance (here `0.05^2`) exactly, for both scalar and vector RF interfaces.
+        _, σs²_false = Emulators.predict(em_srfi, new_inputs; add_obs_noise_cov = false)
+        @test all(isapprox.(vec(σs²) .- vec(σs²_false), 0.05^2, atol = 1e-10))
+
+        _, σv²_false = Emulators.predict(em_vrfi, new_inputs; add_obs_noise_cov = false)
+        @test all(isapprox.(vec(σv²) .- vec(σv²_false), 0.05^2, atol = 1e-10))
+
 
 
 

--- a/test/Show/runtests.jl
+++ b/test/Show/runtests.jl
@@ -202,7 +202,8 @@ const MCMC = MarkovChainMonteCarlo
         prior = constrained_gaussian("x", 0.0, 1.0, -Inf, Inf; repeats = 3)
         iop = PairedDataContainer(rand(3, 5), rand(2, 5), data_are_columns = true)
         ni = NoiseInjector(rand(2, 3), rand(3, 1), rand(2, 1), nothing, 0.5, true, [])
-        fmw = ForwardMapWrapper{Float64, Vector{Any}, typeof(prior), typeof(ni)}(identity, prior, iop, iop, [], ni)
+        fmw =
+            ForwardMapWrapper{Float64, Vector{Any}, typeof(prior), typeof(ni)}(identity, prior, iop, iop, [], ni, nothing)
         out = sprint(show, MIME("text/plain"), fmw)
         @test occursin("ForwardMapWrapper", out)
         @test count(==('\n'), out) <= 10

--- a/test/Show/runtests.jl
+++ b/test/Show/runtests.jl
@@ -202,8 +202,15 @@ const MCMC = MarkovChainMonteCarlo
         prior = constrained_gaussian("x", 0.0, 1.0, -Inf, Inf; repeats = 3)
         iop = PairedDataContainer(rand(3, 5), rand(2, 5), data_are_columns = true)
         ni = NoiseInjector(rand(2, 3), rand(3, 1), rand(2, 1), nothing, 0.5, true, [])
-        fmw =
-            ForwardMapWrapper{Float64, Vector{Any}, typeof(prior), typeof(ni)}(identity, prior, iop, iop, [], ni, nothing)
+        fmw = ForwardMapWrapper{Float64, Vector{Any}, typeof(prior), typeof(ni)}(
+            identity,
+            prior,
+            iop,
+            iop,
+            [],
+            ni,
+            nothing,
+        )
         out = sprint(show, MIME("text/plain"), fmw)
         @test occursin("ForwardMapWrapper", out)
         @test count(==('\n'), out) <= 10

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -172,7 +172,7 @@ end
     # Resolution test (Step 7c): replacing λI with Diagonal(fill(λ, d)) must not throw
     @test size(create_compact_linear_map(Diagonal(fill(3.0, 3)))) == (3, 3)
 
-    # h12: an unsupported block type must throw a clear ArgumentError, not silently
+    # an unsupported block type must throw a clear ArgumentError, not silently
     # produce a zero-size block (which previously surfaced as a distant BoundsError)
     let thrown = @test_throws ArgumentError create_compact_linear_map([1])
         @test contains(thrown.value.msg, "unsupported")
@@ -297,7 +297,7 @@ end
         @test contains(thrown.value.msg, "Float64")
     end
 
-    # h12: `==` across different DataContainerProcessor/PairedDataContainerProcessor
+    # `==` across different DataContainerProcessor/PairedDataContainerProcessor
     # concrete types must return false, not throw a FieldError from mismatched fieldnames
     QQ2 = ElementwiseScaler{QuartileScaling, Vector{Int}, Vector, Vector, Vector, Vector}([1], [2], [3], [4], [5], [6])
     @test QQ == QQ2
@@ -306,8 +306,8 @@ end
     @test !(cc3 == ll3)
     @test !(ll3 == cc3)
 
-    # M7 regression test: the composite-trapezoid weights over the α-path must be
-    # paired with their own node, not shifted by one (see full-code-review M7).
+    # regression test: the composite-trapezoid weights over the α-path must be
+    # paired with their own node, not shifted by one.
     # Construction: for each of 3 nodes, samples_in is the fixed zero-mean basis
     # [e1 -e1 e2 -e2] (population covariance 0.5*I), and samples_out = grad_it * samples_in
     # exactly (no noise), so :linreg regression recovers grad_it exactly. With
@@ -335,7 +335,7 @@ end
             li_m7,
             basis_in,
             zeros(2, 4),
-            Dict(:prior_cov => Matrix{Float64}(I, 2, 2)), # whitened: keep this test focused on M7, not M8
+            Dict(:prior_cov => Matrix{Float64}(I, 2, 2)), # whitened: keep this test focused on the trapezoid-weight fix, not the prior-preconditioning warning
             Dict(:obs_noise_cov => Matrix{Float64}(I, 2, 2)),
             Dict(:dt => alphas_nodes, :samples_in => [basis_in, basis_in, basis_in]),
             Dict(:observation => [zeros(2)], :samples_out => samples_out_it),
@@ -357,7 +357,7 @@ end
         @test norm(off_diag_buggy) > 1e-3
     end
 
-    # M8 regression test: LikelihoodInformed's input-space diagnostic silently assumed
+    # regression test: LikelihoodInformed's input-space diagnostic silently assumed
     # prior covariance ≈ I; it must now warn when apply_to == "in" and the input
     # structure matrices' :prior_cov is missing or not ≈ I, and stay silent when it is.
     let
@@ -638,7 +638,7 @@ end
 
     end
 
-    # G3 regression test: CanonicalCorrelation must not blow up (Inf/NaN, or select the wrong
+    # regression test: CanonicalCorrelation must not blow up (Inf/NaN, or select the wrong
     # in/out role) on rank-deficient (collinear-ensemble) data.
     let
         rng_deg = Random.MersenneTwister(2026)
@@ -665,7 +665,7 @@ end
         @test isapprox(norm(dec_out_deg - out_data_deg), 0.0, atol = 1e-8 * samples_deg)
     end
 
-    # G3 regression test: ElementwiseScaler (ZScore/MinMax/Quartile) must not divide by a zero
+    # regression test: ElementwiseScaler (ZScore/MinMax/Quartile) must not divide by a zero
     # scale (constant data dimension) and must warn rather than silently producing NaN/Inf.
     let
         rng_deg = Random.MersenneTwister(2027)
@@ -857,7 +857,7 @@ end
 
 end
 
-@testset "M6: encoder schedules do not share fitted processor state" begin
+@testset "encoder schedules do not share fitted processor state" begin
     rng_m6 = Random.MersenneTwister(20260731)
     dim_m6 = 3
     samples_m6 = 30
@@ -1020,8 +1020,8 @@ end
 
 end
 
-@testset "Decorrelator: small/large-matrix truncation criterion consistency (m28)" begin
-    # m28 regression test. The large-matrix (tsvd) branch must truncate on the same VARIANCE
+@testset "Decorrelator: small/large-matrix truncation criterion consistency" begin
+    # regression test. The large-matrix (tsvd) branch must truncate on the same VARIANCE
     # (trace, Σσᵢ) fraction the small-matrix branch computes exactly, not the sum-of-squares
     # (Frobenius, Σσᵢ²) fraction it used before. Isolated from the (pre-existing, out-of-scope)
     # conservative retain_var deflation the tsvd branch applies for estimator uncertainty - that
@@ -1065,7 +1065,7 @@ end
         io_pairs_large;
         output_structure_mats = Dict{Symbol, Utilities.StructureMatrix}(:obs_noise_cov => C_large),
     )
-    # `create_encoder_schedule` deepcopies its processor (M6), so the fitted state lives on
+    # `create_encoder_schedule` deepcopies its processor, so the fitted state lives on
     # the copy inside `enc_sch_large`, not on `dd_large` itself - retrieve it from there.
     achieved_rank_large = size(get_encoder_mat(enc_sch_large[1][1])[1], 1)
     @test 0 < achieved_rank_large < d_large


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- closes #451 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
Emulators:
- Remove the safeguard "I" for deterministic maps, replace with `0`
- rectified different emulators adding different "observational" noise on predictions - and centralize the addition of noise to outside of the predict(machine_learning_tool) call
- encoded noise is now stored- thus not assuming it must be `I`

GPs
- performance unification between different GP backends
- exact GP posterior Check tests
- warning if off-diagonal structure is present in covariances when it should not be
- remove some hard-coded Float64.

RFs:
- NICE correlation formula
- RF prior option was being ignored
- some docstring inconsistencies and outdated keywords
- guard if n_cov_samples < 2

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.
- 
-->

----
- [ ] I have read and checked the items on the review checklist.
